### PR TITLE
Inspector Release 6.2.1

### DIFF
--- a/.github/workflows/pack-package.yml
+++ b/.github/workflows/pack-package.yml
@@ -72,6 +72,7 @@ jobs:
         if: startsWith(github.ref, 'refs/heads/main')
         with:
           tag_name: "v${{ steps.version.outputs.prop }}"
+          draft: true
           files: |
             ${{ env.zipFile }}
         # ${{ env.unityPackage }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,14 +83,14 @@ jobs:
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         if: startsWith(github.ref, 'refs/heads/main')
         with:
-          tag_name: "v${{ (inputs.package-name == 'All' || inputs.package-name == 'Shaders') ? steps.version-all.outputs.prop : (inputs.package-name == 'Generator' ? steps.version-generator.outputs.prop : steps.version-inspector.outputs.prop ) }}"
+          tag_name: "v${{ ((inputs.package-name == 'All' || inputs.package-name == 'Shaders') && steps.version-all.outputs.prop) || (inputs.package-name == 'Generator' && steps.version-generator.outputs.prop) || steps.version-inspector.outputs.prop }}"
           generate_release_notes: true
 
       - name: Make Pre-Release
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         if: startsWith(github.ref, 'refs/heads/dev')
         with:
-          tag_name: "v${{ (inputs.package-name == 'All' || inputs.package-name == 'Shaders') ? steps.version-all.outputs.prop : (inputs.package-name == 'Generator' ? steps.version-generator.outputs.prop : steps.version-inspector.outputs.prop ) }}"
+          tag_name: "v${{ ((inputs.package-name == 'All' || inputs.package-name == 'Shaders') && steps.version-all.outputs.prop) || (inputs.package-name == 'Generator' && steps.version-generator.outputs.prop) || steps.version-inspector.outputs.prop }}"
           draft: true
           prerelease: true
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,16 @@ name: Build Release
 
 on: 
   workflow_dispatch:
+      inputs:
+        package-name:
+          description: 'Name of the package to release'
+          required: true
+          type: choice
+          options:
+            - All
+            - Shaders
+            - Generator
+            - Inspector
   # push:
   #   branches:
   #     - main
@@ -13,19 +23,22 @@ on:
 
 jobs:
   pack-shaders:
+    if: ${{ inputs.package-name == 'All' || inputs.package-name == 'Shaders' }}
     uses: ./.github/workflows/pack-package.yml
     with:
       package-name: "sh.orels.shaders"
 
   pack-inspector:
     uses: ./.github/workflows/pack-package.yml
-    needs: pack-shaders
+    if: ${{ inputs.package-name == 'All' || inputs.package-name == 'Inspector' }}
+#    needs: pack-shaders
     with:
       package-name: "sh.orels.shaders.inspector"
 
   pack-generator:
+    if: ${{ inputs.package-name == 'All' || inputs.package-name == 'Generator' }}
     uses: ./.github/workflows/pack-package.yml
-    needs: [pack-shaders, pack-inspector]
+#    needs: [pack-shaders, pack-inspector]
     with:
       package-name: "sh.orels.shaders.generator"
 
@@ -35,6 +48,7 @@ jobs:
 
   update-release:
     needs: [pack-shaders, pack-inspector, pack-generator]
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
 
@@ -42,11 +56,28 @@ jobs:
         uses: actions/checkout@v3
       
       - name: get version
+        if: ${{ inputs.package-name == 'All' || inputs.package-name == 'Shaders' }}
         id: version
         uses: notiz-dev/github-action-json-property@7c8cf5cc36eb85d8d287a8086a39dac59628eb31
         with: 
             path: "Packages/sh.orels.shaders/package.json"
             prop_path: "version"
+            
+      - name: get version (Generator)
+        if: ${{ inputs.package-name == 'Generator' }}
+        id: version
+        uses: notiz-dev/github-action-json-property@7c8cf5cc36eb85d8d287a8086a39dac59628eb31
+        with:
+          path: "Packages/sh.orels.shaders.generator/package.json"
+          prop_path: "version"
+
+      - name: get version (Inspector)
+        if: ${{ inputs.package-name == 'Inspector' }}
+        id: version
+        uses: notiz-dev/github-action-json-property@7c8cf5cc36eb85d8d287a8086a39dac59628eb31
+        with:
+          path: "Packages/sh.orels.shaders.inspector/package.json"
+          prop_path: "version"
 
       - name: Make Release
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       
       - name: get version
         if: ${{ inputs.package-name == 'All' || inputs.package-name == 'Shaders' }}
-        id: version
+        id: version-all
         uses: notiz-dev/github-action-json-property@7c8cf5cc36eb85d8d287a8086a39dac59628eb31
         with: 
             path: "Packages/sh.orels.shaders/package.json"
@@ -65,7 +65,7 @@ jobs:
             
       - name: get version (Generator)
         if: ${{ inputs.package-name == 'Generator' }}
-        id: version
+        id: version-generator
         uses: notiz-dev/github-action-json-property@7c8cf5cc36eb85d8d287a8086a39dac59628eb31
         with:
           path: "Packages/sh.orels.shaders.generator/package.json"
@@ -73,7 +73,7 @@ jobs:
 
       - name: get version (Inspector)
         if: ${{ inputs.package-name == 'Inspector' }}
-        id: version
+        id: version-inspector
         uses: notiz-dev/github-action-json-property@7c8cf5cc36eb85d8d287a8086a39dac59628eb31
         with:
           path: "Packages/sh.orels.shaders.inspector/package.json"
@@ -83,14 +83,14 @@ jobs:
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         if: startsWith(github.ref, 'refs/heads/main')
         with:
-          tag_name: "v${{ steps.version.outputs.prop }}"
+          tag_name: "v${{ (inputs.package-name == 'All' || inputs.package-name == 'Shaders') ? steps.version-all.outputs.prop : (inputs.package-name == 'Generator' ? steps.version-generator.outputs.prop : steps.version-inspector.outputs.prop ) }}"
           generate_release_notes: true
 
       - name: Make Pre-Release
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         if: startsWith(github.ref, 'refs/heads/dev')
         with:
-          tag_name: "v${{ steps.version.outputs.prop }}"
+          tag_name: "v${{ (inputs.package-name == 'All' || inputs.package-name == 'Shaders') ? steps.version-all.outputs.prop : (inputs.package-name == 'Generator' ? steps.version-generator.outputs.prop : steps.version-inspector.outputs.prop ) }}"
           draft: true
           prerelease: true
           generate_release_notes: true

--- a/Packages/sh.orels.shaders.inspector/Editor/Drawers/HeaderDrawer.cs
+++ b/Packages/sh.orels.shaders.inspector/Editor/Drawers/HeaderDrawer.cs
@@ -43,6 +43,9 @@ namespace ORL.Drawers
                 var rect = EditorGUILayout.GetControlRect();
                 rect.yMax += 1f * EditorGUIUtility.pixelsPerPoint;
                 rect.xMin -= 15f * EditorGUIUtility.pixelsPerPoint;
+                #if UNITY_2022_1_OR_NEWER
+                rect.xMin -= 15f * EditorGUIUtility.pixelsPerPoint;
+                #endif
                 rect.xMax += 5f * EditorGUIUtility.pixelsPerPoint;
                 var dividerRect = rect;
                 dividerRect.y -= 1f;

--- a/Packages/sh.orels.shaders.inspector/Editor/InspectorGUI.cs
+++ b/Packages/sh.orels.shaders.inspector/Editor/InspectorGUI.cs
@@ -446,12 +446,34 @@ namespace ORL.ShaderInspector
                         .ToList()
                         .ForEach(g => groups.Add(g.Value));
                 }
+                #if UNITY_2022_1_OR_NEWER
+                var oldIndentLevel = EditorGUI.indentLevel;
+                var shouldRestore = oldIndentLevel != -1;
+                EditorGUI.indentLevel = oldIndentLevel != -1 ? Mathf.Max(0, EditorGUI.indentLevel - 1) : oldIndentLevel;
+                #endif
                 drawn = MatchDrawerFuncStack(groups, editor, properties, property, index);
+                #if UNITY_2022_1_OR_NEWER
+                if (shouldRestore && EditorGUI.indentLevel != -1)
+                {
+                    EditorGUI.indentLevel = oldIndentLevel;
+                }
+                #endif
             }
 
             if (!drawn)
             {
+                #if UNITY_2022_1_OR_NEWER
+                var oldIndentLevel = EditorGUI.indentLevel;
+                var shouldRestore = oldIndentLevel != -1;
+                EditorGUI.indentLevel = oldIndentLevel != -1 ? Mathf.Max(0, EditorGUI.indentLevel - 1) : oldIndentLevel;
+                #endif
                 drawn = MatchDrawerStack(drawerStack, editor, properties, property, index);
+                #if UNITY_2022_1_OR_NEWER
+                if (shouldRestore && EditorGUI.indentLevel != -1)
+                {
+                    EditorGUI.indentLevel = oldIndentLevel;
+                }
+                #endif
             }
             return drawn;
         }
@@ -460,6 +482,12 @@ namespace ORL.ShaderInspector
 
         public void DrawRegularProp(MaterialEditor editor, MaterialProperty[] properties, MaterialProperty property, int index)
         {
+            #if UNITY_2022_1_OR_NEWER
+            var oldIndentLevel = EditorGUI.indentLevel;
+            var shouldRestore = oldIndentLevel != -1;
+            EditorGUI.indentLevel = oldIndentLevel != -1 ? Mathf.Max(0, EditorGUI.indentLevel - 1) : oldIndentLevel;
+            #endif
+            
             var strippedName = Utils.StripInternalSymbols(property.displayName);
             var isSingleLine = property.type == MaterialProperty.PropType.Texture && _singleLineRegex.IsMatch(property.displayName);
             var defaultProps =
@@ -486,6 +514,12 @@ namespace ORL.ShaderInspector
                 if (property.textureDimension != TextureDimension.Tex2D) return;
                 var packerKey = property.name + "_packer";
                 _uiState[packerKey] = TexturePacker.DrawPacker(buttonRect, (bool) _uiState[packerKey], ref _uiState, packerKey, editor.target as Material, property, editor);
+                #if UNITY_2022_1_OR_NEWER
+                if (shouldRestore)
+                {
+                    EditorGUI.indentLevel = oldIndentLevel;
+                }
+                #endif
                 return;
             }
 
@@ -507,9 +541,21 @@ namespace ORL.ShaderInspector
                 if (property.textureDimension != TextureDimension.Tex2D) return;
                 var packerKey = property.name + "_packer";
                 _uiState[packerKey] = TexturePacker.DrawPacker(buttonRect, (bool) _uiState[packerKey], ref _uiState, packerKey, editor.target as Material, property, editor);
+                #if UNITY_2022_1_OR_NEWER
+                if (shouldRestore && EditorGUI.indentLevel != -1)
+                {
+                    EditorGUI.indentLevel = oldIndentLevel;
+                }
+                #endif
                 return;
             }
             editor.ShaderProperty(controlRect, property, new GUIContent(strippedName, tooltip));
+            #if UNITY_2022_1_OR_NEWER
+            if (shouldRestore)
+            {
+                EditorGUI.indentLevel = oldIndentLevel;
+            }
+            #endif
         }
         #endregion
 
@@ -517,6 +563,9 @@ namespace ORL.ShaderInspector
         {
             Styles.DrawStaticHeader("Extras");
             EditorGUI.indentLevel = 1;
+            #if UNITY_2022_1_OR_NEWER
+            EditorGUI.indentLevel = 0;
+            #endif
             editor.RenderQueueField();
             editor.EnableInstancingField();
             editor.LightmapEmissionFlagsProperty(0, true, true);
@@ -535,6 +584,11 @@ namespace ORL.ShaderInspector
             }
 
             if (!newValue) return;
+            
+            #if UNITY_2022_1_OR_NEWER
+            // Unity 2022 is 1 more level nested
+            EditorGUI.indentLevel = 0;
+            #endif
 
             EditorGUILayout.LabelField("Active Keywords", EditorStyles.boldLabel);
             using (new EditorGUI.DisabledGroupScope(true)) {

--- a/Packages/sh.orels.shaders.inspector/Editor/MaterialLibraries/AmbientCGBrowser.cs
+++ b/Packages/sh.orels.shaders.inspector/Editor/MaterialLibraries/AmbientCGBrowser.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_2019_4
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -439,3 +440,4 @@ namespace ORL.ShaderInspector.MaterialLibraries
         }
     }
 }
+#endif

--- a/Packages/sh.orels.shaders.inspector/Editor/Requests.cs
+++ b/Packages/sh.orels.shaders.inspector/Editor/Requests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if UNITY_2019_4
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -106,3 +107,4 @@ namespace ORL.ShaderInspector
         }
     }
 }
+#endif

--- a/Packages/sh.orels.shaders.inspector/Editor/Styles.cs
+++ b/Packages/sh.orels.shaders.inspector/Editor/Styles.cs
@@ -141,6 +141,9 @@ namespace ORL.ShaderInspector
             var rect = EditorGUILayout.GetControlRect();
             rect.yMax += 1f * EditorGUIUtility.pixelsPerPoint;
             rect.xMin -= 15f * EditorGUIUtility.pixelsPerPoint;
+            #if UNITY_2022_1_OR_NEWER
+            rect.xMin -= 15f * EditorGUIUtility.pixelsPerPoint;
+            #endif
             rect.xMax += 5f * EditorGUIUtility.pixelsPerPoint;
             var dividerRect = rect;
             dividerRect.y -= 1f;
@@ -160,6 +163,9 @@ namespace ORL.ShaderInspector
             var rect = EditorGUILayout.GetControlRect();
             rect.yMax += 1f * EditorGUIUtility.pixelsPerPoint;
             rect.xMin -= 15f * EditorGUIUtility.pixelsPerPoint;
+            #if UNITY_2022_1_OR_NEWER
+            rect.xMin -= 15f * EditorGUIUtility.pixelsPerPoint;
+            #endif
             rect.xMax += 5f * EditorGUIUtility.pixelsPerPoint;
             var dividerRect = rect;
             dividerRect.y -= 1f;

--- a/Packages/sh.orels.shaders.inspector/package.json
+++ b/Packages/sh.orels.shaders.inspector/package.json
@@ -2,7 +2,7 @@
   "name": "sh.orels.shaders.inspector",
   "displayName": "ORL Shader Inspector",
   "description": "A simple property-based shader inspector with extension support",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "unity": "2019.4",
   "author": {
     "name": "orels1",


### PR DESCRIPTION
This fixes compatibility with Unity 2021 (Newtonsoft) and Unity 2022 (Material Variants) in the ORL Shader Inspector.

This also adjusts the github workflow to support publishing individual packages if necessary