### PR TITLE
Makes "Hide from Main View" options match the behavior described in the docs.

### DIFF
--- a/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/VRCFeatures.orlsource
+++ b/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/VRCFeatures.orlsource
@@ -46,12 +46,12 @@
         bool isInVRMirror = _VRChatMirrorMode == 1;
         bool isInDesktopMirror = _VRChatMirrorMode == 2;
 
-        if (_VRCHideInVR && isInVR)
+        if (_VRCHideInVR && isInVR && !(isInVRMirror || isInVRHandCam))
         {
             v.vertex = asfloat(-1);
             return;
         }
-        if (_VRCHideInDesktop && isInDesktop)
+        if (_VRCHideInDesktop && isInDesktop && !(isInDesktopMirror || isInDesktopHandCam))
         {
             v.vertex = asfloat(-1);
             return;


### PR DESCRIPTION
This would break compatibility with materials using current version of the shader.

The "Hide from Main View" options seem to just hide the geometry completely (for cameras and mirrors too) rather than hiding only in the main view. The docs & property labels imply these work the same way as the other 4 options for just the mirror or camera views.