### PR TITLE
Fix dissolve module not dissolving fully

### DIFF
--- a/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/Dissolve.orlsource
+++ b/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/Dissolve.orlsource
@@ -69,7 +69,7 @@
 %Fragment("DissolveFragment")
 {
     void DissolveFragment(MeshData d, inout SurfaceData o) {
-        _DissolveCutoff = remap(_DissolveCutoff, 0, 1, -0.1, 1);
+        _DissolveCutoff = remap(_DissolveCutoff, 0, 1, -0.1, 1.1);
         half gradSource = 0;
         uint totalChannels = 3;
         switch (_DissolveSource) {


### PR DESCRIPTION
Currently when _DissolveCutoff is set to 1, a small amount of the glowing border can still be visible.
This change adjusts the remap to increase the max value to 1.1 in the same way that the min value is -0.1.
This appears to be all that is needed to ensure that no border is visible when fully dissolved.