### PR TITLE
Don't set Alpha in Opaque / Cutout

### DIFF
--- a/Packages/sh.orels.shaders.generator/Runtime/Sources/Functions/PBR/FragmentBase.orlsource
+++ b/Packages/sh.orels.shaders.generator/Runtime/Sources/Functions/PBR/FragmentBase.orlsource
@@ -940,7 +940,9 @@
         // Compositing
         FinalColor.rgb *= diffuseContributions;
         FinalColor.rgb += specularContributions;
-        FinalColor.a = o.Alpha;
+
+        if (_RenderType > 1)
+            FinalColor.a = o.Alpha;
         
         #if defined(UNITY_PASS_FORWARDBASE)
         FinalColor.rgb += o.Emission;


### PR DESCRIPTION
This fixes Opaque / Cutout modes with Transparent textures rendering incorrectly in Cutout / Transparent Mirrors