### PR TITLE
Added VRC Light Volumes support

### DIFF
--- a/Packages/sh.orels.shaders.generator/Runtime/Sources/Functions/PBR/FragmentBase.orlsource
+++ b/Packages/sh.orels.shaders.generator/Runtime/Sources/Functions/PBR/FragmentBase.orlsource
@@ -235,7 +235,7 @@
         float oneMinusReflectivity = 1.0 - 0.04 - o.Metallic * (1.0 - 0.04);
         half3 f0 = 0.16 * reflectance * reflectance * oneMinusReflectivity + o.Albedo * o.Metallic;
 
-        half3 indirectDiffuse = 1;
+        half3 indirectDiffuse = 0;
         half3 indirectSpecular = 0;
         
         half occlusion = o.Occlusion;
@@ -411,7 +411,7 @@
 
         // READ THE LIGHTMAP
         // Can be Baked, Realtime, both or either
-        #if (defined(LIGHTMAP_ON) || defined(DYNAMICLIGHTMAP_ON)) && !defined(UNITY_PASS_FORWARDADD)
+        #if (defined(LIGHTMAP_ON) || defined(DYNAMICLIGHTMAP_ON)) && defined(UNITY_PASS_FORWARDBASE)
             half3 lightMap = 0;
             half4 bakedColorTex = 0;
             half2 lightmapUV = d.lightmapUv.xy;
@@ -546,7 +546,12 @@
             );
 
         // Lightprobes Sampling
-        #else
+        #elif defined(UNITY_PASS_FORWARDBASE)
+            #if defined(_INTEGRATE_CUSTOMPROBES)
+            {
+                %CustomProbesSetupFunctions
+            }
+            #endif
             // LPPV support
             #if UNITY_LIGHT_PROBE_PROXY_VOLUME
             {

--- a/Packages/sh.orels.shaders.generator/Runtime/Sources/Functions/PBR/FragmentBase.orlsource
+++ b/Packages/sh.orels.shaders.generator/Runtime/Sources/Functions/PBR/FragmentBase.orlsource
@@ -557,9 +557,42 @@
                 }
                 else // Mesh has BlendProbes instead of LPPV
                 {
+                    // Enable Integration of Custom Lightprobe solutions
+                    #if defined(_INTEGRATE_CUSTOMPROBES)
+                    {
+                        %CustomProbesFunctions
+                    }
+                    #else
+                    {
+                        #if defined(NONLINEAR_SH)
+                        {
+                            half3 L0 = half3(unity_SHAr.w, unity_SHAg.w, unity_SHAb.w);
+                            half3 L0L2 = half3(unity_SHBr.z, unity_SHBg.z, unity_SHBb.z) / 3.0;
+                            L0 = L0+L0L2;
+                            indirectDiffuse = max(0, GetNonLinearSH(L0, unity_SHAr, unity_SHAg, unity_SHAb, o.Normal));
+                            indirectDiffuse += SHEvalLinearL2(float4(o.Normal, 1));
+                        }
+                        #else
+                        {
+                            indirectDiffuse = max(0, ShadeSH9(half4(o.Normal, 1)));   
+                        }
+                        #endif
+                    }
+                    #endif
+                }
+            }
+            #else // No LPPVs enabled project-wide
+            {
+                // Enable Integration of Custom Lightprobe solutions
+                #if defined(_INTEGRATE_CUSTOMPROBES)
+                {
+                    %CustomProbesFunctions
+                }
+                #else
+                {
                     #if defined(NONLINEAR_SH)
                     {
-                        half3 L0 = float3(unity_SHAr.w, unity_SHAg.w, unity_SHAb.w);
+                        half3 L0 = half3(unity_SHAr.w, unity_SHAg.w, unity_SHAb.w);
                         half3 L0L2 = half3(unity_SHBr.z, unity_SHBg.z, unity_SHBb.z) / 3.0;
                         L0 = L0+L0L2;
                         indirectDiffuse = max(0, GetNonLinearSH(L0, unity_SHAr, unity_SHAg, unity_SHAb, o.Normal));
@@ -570,21 +603,6 @@
                         indirectDiffuse = max(0, ShadeSH9(half4(o.Normal, 1)));   
                     }
                     #endif
-                }
-            }
-            #else // No LPPVs enabled project-wide
-            {
-                #if defined(NONLINEAR_SH)
-                {
-                    half3 L0 = half3(unity_SHAr.w, unity_SHAg.w, unity_SHAb.w);
-                    half3 L0L2 = half3(unity_SHBr.z, unity_SHBg.z, unity_SHBb.z) / 3.0;
-                    L0 = L0+L0L2;
-                    indirectDiffuse = max(0, GetNonLinearSH(L0, unity_SHAr, unity_SHAg, unity_SHAb, o.Normal));
-                    indirectDiffuse += SHEvalLinearL2(float4(o.Normal, 1));
-                }
-                #else
-                {
-                    indirectDiffuse = max(0, ShadeSH9(half4(o.Normal, 1)));   
                 }
                 #endif
             }
@@ -675,6 +693,13 @@
             #if !defined(LIGHTMAP_ON)
             bakedSpecularColor = half3(unity_SHAr.w, unity_SHAg.w, unity_SHAb.w);
             bakedDominantDirection = unity_SHAr.xyz + unity_SHAg.xyz + unity_SHAb.xyz;
+
+            // Enable Custom Lightprobes to write to baked specular
+            #if defined(_INTEGRATE_CUSTOMPROBES)
+            {
+                %CustomProbesBakedSpecularFunctions
+            }
+            #endif
             #endif
 
             bakedDominantDirection = normalize(bakedDominantDirection);

--- a/Packages/sh.orels.shaders.generator/Runtime/Sources/Functions/Toon/v2/FragmentBase.orlsource
+++ b/Packages/sh.orels.shaders.generator/Runtime/Sources/Functions/Toon/v2/FragmentBase.orlsource
@@ -64,8 +64,19 @@
         float3 lightDir = _WorldSpaceLightPos0.xyz;
         #endif
         bool hasRealtimeLight = any(lightDir.xyz);
-        float3 probeLightDir = unity_SHAr.xyz + unity_SHAg.xyz + unity_SHAb.xyz;
-        bool probesAreBlack = length(dot(probeLightDir, float3(unity_SHAr.w, unity_SHAg.w, unity_SHAb.w))) < 0.01;
+
+        float3 probeLightDir = 0;
+        bool probesAreBlack = false;
+        
+        // Custom probes might want to override the probe light direction
+        #if defined(_INTEGRATE_CUSTOMPROBES)
+        {
+            %CustomProbesSetupFunctions
+        }        
+        #endif
+        probeLightDir = unity_SHAr.xyz + unity_SHAg.xyz + unity_SHAb.xyz;
+        probesAreBlack = length(dot(probeLightDir, float3(unity_SHAr.w, unity_SHAg.w, unity_SHAb.w))) < 0.01;
+
         bool noLightDir = !hasRealtimeLight && probesAreBlack;
 
         // If no realtime light is present - use direction from probes

--- a/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/Toon/v2/Decals.orlsource
+++ b/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/Toon/v2/Decals.orlsource
@@ -16,6 +16,7 @@
 
     UI_Decal0ColorsHeader("### Colors %ShowIf(DECAL_0)", Int) = 0
     _Decal0Tint("Tint %ShowIf(DECAL_0)", Color) = (1,1,1,1)
+    _Decal0MultiplyByAlbedo("Multiply By Albedo %ShowIf(DECAL_0)", Range(0, 1)) = 0
     [ToggleUI]_Decal0UseEmission("Use Emission %ShowIf(DECAL_0)", Int) = 0
     _Decal0EmissionStrength("Emission Strength %ShowIf(DECAL_0 && _Decal0UseEmission)", Float) = 0
     [ToggleUI]_Decal0RimFade("Rim Fade %ShowIf(DECAL_0)", Int) = 0
@@ -35,7 +36,7 @@
 
     UI_DecalsLayer2Header("## Layer 2", Int) = 0
     [Toggle(DECAL_1)]_Decal1Enabled("Enable Layer 2", Int) = 0
-    _Decal1Map("Decal %ShowIf(DECAL_1)", 2D) = "white" {}
+    _Decal1Map("Decal > %ShowIf(DECAL_1)", 2D) = "white" {}
     [Enum(UV1, 0, UV2, 1, UV3, 2, UV4, 3)]_Decal1UVSet("UV Set %ShowIf(_Decal1Map && DECAL_1)", Int) = 0
     _Decal1Scale("Scale %ShowIf(_Decal1Map && DECAL_1)", Float) = 1
     _Decal1Offset("Offset %ShowIf(_Decal1Map && DECAL_1) %Vector2(Offset X, Y)", Vector) = (0,0,0,0)
@@ -45,6 +46,7 @@
 
     UI_Decal1ColorsHeader("### Colors %ShowIf(DECAL_1)", Int) = 0
     _Decal1Tint("Tint %ShowIf(DECAL_1)", Color) = (1,1,1,1)
+    _Decal1MultiplyByAlbedo("Multiply By Albedo %ShowIf(DECAL_1)", Range(0, 1)) = 0
     [ToggleUI]_Decal1UseEmission("Use Emission %ShowIf(DECAL_1)", Int) = 0
     _Decal1EmissionStrength("Emission Strength %ShowIf(DECAL_1 && _Decal1UseEmission)", Float) = 0
     [ToggleUI]_Decal1RimFade("Rim Fade %ShowIf(DECAL_1)", Int) = 0
@@ -64,7 +66,7 @@
 
     UI_DecalsLayer3Header("## Layer 3", Int) = 0
     [Toggle(DECAL_2)]_Decal2Enabled("Enable Layer 3", Int) = 0
-    _Decal2Map("Decal %ShowIf(DECAL_2)", 2D) = "white" {}
+    _Decal2Map("Decal > %ShowIf(DECAL_2)", 2D) = "white" {}
     [Enum(UV1, 0, UV2, 1, UV3, 2, UV4, 3)]_Decal2UVSet("UV Set %ShowIf(_Decal2Map && DECAL_2)", Int) = 0
     _Decal2Scale("Scale %ShowIf(_Decal2Map && DECAL_2)", Float) = 1
     _Decal2Offset("Offset %ShowIf(_Decal2Map && DECAL_2) %Vector2(Offset X, Y)", Vector) = (0,0,0,0)
@@ -74,6 +76,7 @@
     
     UI_Decal2ColorsHeader("### Colors %ShowIf(DECAL_2)", Int) = 0
     _Decal2Tint("Tint %ShowIf(DECAL_2)", Color) = (1,1,1,1)
+    _Decal2MultiplyByAlbedo("Multiply By Albedo %ShowIf(DECAL_2)", Range(0, 1)) = 0
     [ToggleUI]_Decal2UseEmission("Use Emission %ShowIf(DECAL_2)", Int) = 0
     _Decal2EmissionStrength("Emission Strength %ShowIf(DECAL_2 && _Decal2UseEmission)", Float) = 0
     [ToggleUI]_Decal2RimFade("Rim Fade %ShowIf(DECAL_2)", Int) = 0
@@ -93,7 +96,7 @@
 
     UI_DecalsLayer4Header("## Layer 4", Int) = 0
     [Toggle(DECAL_3)]_Decal3Enabled("Enable Layer 4", Int) = 0
-    _Decal3Map("Decal %ShowIf(DECAL_3)", 2D) = "white" {}
+    _Decal3Map("Decal > %ShowIf(DECAL_3)", 2D) = "white" {}
     [Enum(UV1, 0, UV2, 1, UV3, 2, UV4, 3)]_Decal3UVSet("UV Set %ShowIf(_Decal3Map && DECAL_3)", Int) = 0
     _Decal3Scale("Scale %ShowIf(_Decal3Map && DECAL_3)", Float) = 1
     _Decal3Offset("Offset %ShowIf(_Decal3Map && DECAL_3) %Vector2(Offset X, Y)", Vector) = (0,0,0,0)
@@ -103,6 +106,7 @@
     
     UI_Decal3ColorsHeader("### Colors %ShowIf(DECAL_3)", Int) = 0
     _Decal3Tint("Tint %ShowIf(DECAL_3)", Color) = (1,1,1,1)
+    _Decal3MultiplyByAlbedo("Multiply By Albedo %ShowIf(DECAL_3)", Range(0, 1)) = 0
     [ToggleUI]_Decal3UseEmission("Use Emission %ShowIf(DECAL_3)", Int) = 0
     _Decal3EmissionStrength("Emission Strength %ShowIf(DECAL_3 && _Decal3UseEmission)", Float) = 0
     [ToggleUI]_Decal3RimFade("Rim Fade %ShowIf(DECAL_3)", Int) = 0
@@ -145,6 +149,7 @@
     float2 _Decal0Tiling;
 
     half4 _Decal0Tint;
+    half _Decal0MultiplyByAlbedo;
     int _Decal0UseEmission;
     half _Decal0EmissionStrength;
     int _Decal0RimFade;
@@ -169,6 +174,7 @@
     float2 _Decal1Tiling;
 
     half4 _Decal1Tint;
+    half _Decal1MultiplyByAlbedo;
     int _Decal1UseEmission;
     half _Decal1EmissionStrength;
     int _Decal1RimFade;
@@ -193,6 +199,7 @@
     float2 _Decal2Tiling;
 
     half4 _Decal2Tint;
+    half _Decal2MultiplyByAlbedo;
     int _Decal2UseEmission;
     half _Decal2EmissionStrength;
     int _Decal2RimFade;
@@ -217,6 +224,7 @@
     float2 _Decal3Tiling;
 
     half4 _Decal3Tint;
+    half _Decal3MultiplyByAlbedo;
     int _Decal3UseEmission;
     half _Decal3EmissionStrength;
     int _Decal3RimFade;
@@ -328,11 +336,11 @@
         return decalTexture;
     }
 
-    void CompositeDecal(inout SurfaceData o, half4 decalTexture, half4 maskTexture, int maskChannel, half maskStrength, int useEmission, half emissionStrength)
+    void CompositeDecal(inout SurfaceData o, half4 decalTexture, half4 maskTexture, int maskChannel, half maskStrength, int useEmission, half emissionStrength, half multiplyByAlbedo)
     {
         half mask = maskTexture[maskChannel];
         mask = lerp(1, mask, maskStrength);
-        o.Albedo = lerp(o.Albedo, decalTexture, decalTexture.a * mask);
+        o.Albedo = lerp(o.Albedo, decalTexture * lerp(1, o.Albedo, multiplyByAlbedo), decalTexture.a * mask);
         if (useEmission)
         {
             o.Emission += (decalTexture.rgb * decalTexture.a * mask) * emissionStrength;
@@ -360,7 +368,7 @@
             half4 decalTexture = GetDecalTexture(d, _Decal0UVSet, _Decal0Scale, _Decal0Tile, _Decal0Tiling, _Decal0Offset, _Decal0Rotation, TEXTURE2D_ARGS(_Decal0Map, DecalSampler), _Decal0Tint, decalUV);
             decalTexture = GetDecalRimFade(decalTexture, _Decal0RimFade, _Decal0RimFadeInvert, NoV, _Decal0RimFadePower, _Decal0RimFadeUnderlay);
             decalTexture = GetDecalClip(decalTexture, decalUV, _Decal0Clip, _Decal0ClipCirlce, _Decal0ClipSize, _Decal0ClipFalloff);
-            CompositeDecal(o, decalTexture, decalsMask, _Decal0MaskChannel, _Decal0MaskStrength, _Decal0UseEmission, _Decal0EmissionStrength);
+            CompositeDecal(o, decalTexture, decalsMask, _Decal0MaskChannel, _Decal0MaskStrength, _Decal0UseEmission, _Decal0EmissionStrength, _Decal0MultiplyByAlbedo);
             
         }
         #endif
@@ -372,7 +380,7 @@
             half4 decalTexture = GetDecalTexture(d, _Decal1UVSet, _Decal1Scale, _Decal1Tile, _Decal1Tiling, _Decal1Offset, _Decal1Rotation, TEXTURE2D_ARGS(_Decal1Map, DecalSampler), _Decal1Tint, decalUV);
             decalTexture = GetDecalRimFade(decalTexture, _Decal1RimFade, _Decal1RimFadeInvert, NoV, _Decal1RimFadePower, _Decal1RimFadeUnderlay);
             decalTexture = GetDecalClip(decalTexture, decalUV, _Decal1Clip, _Decal1ClipCirlce, _Decal1ClipSize, _Decal1ClipFalloff);
-            CompositeDecal(o, decalTexture, decalsMask, _Decal1MaskChannel, _Decal1MaskStrength, _Decal1UseEmission, _Decal1EmissionStrength);
+            CompositeDecal(o, decalTexture, decalsMask, _Decal1MaskChannel, _Decal1MaskStrength, _Decal1UseEmission, _Decal1EmissionStrength, _Decal1MultiplyByAlbedo);
         }        
         #endif
 
@@ -383,7 +391,7 @@
             half4 decalTexture = GetDecalTexture(d, _Decal2UVSet, _Decal2Scale, _Decal2Tile, _Decal2Tiling, _Decal2Offset, _Decal2Rotation, TEXTURE2D_ARGS(_Decal2Map, DecalSampler), _Decal2Tint, decalUV);
             decalTexture = GetDecalRimFade(decalTexture, _Decal2RimFade, _Decal2RimFadeInvert, NoV, _Decal2RimFadePower, _Decal2RimFadeUnderlay);
             decalTexture = GetDecalClip(decalTexture, decalUV, _Decal2Clip, _Decal2ClipCirlce, _Decal2ClipSize, _Decal2ClipFalloff);
-            CompositeDecal(o, decalTexture, decalsMask, _Decal2MaskChannel, _Decal2MaskStrength, _Decal2UseEmission, _Decal2EmissionStrength);
+            CompositeDecal(o, decalTexture, decalsMask, _Decal2MaskChannel, _Decal2MaskStrength, _Decal2UseEmission, _Decal2EmissionStrength, _Decal2MultiplyByAlbedo);
         }
         #endif
 
@@ -394,7 +402,7 @@
             half4 decalTexture = GetDecalTexture(d, _Decal3UVSet, _Decal3Scale, _Decal3Tile, _Decal3Tiling, _Decal3Offset, _Decal3Rotation, TEXTURE2D_ARGS(_Decal3Map, DecalSampler), _Decal3Tint, decalUV);
             decalTexture = GetDecalRimFade(decalTexture, _Decal3RimFade, _Decal3RimFadeInvert, NoV, _Decal3RimFadePower, _Decal3RimFadeUnderlay);
             decalTexture = GetDecalClip(decalTexture, decalUV, _Decal3Clip, _Decal3ClipCirlce, _Decal3ClipSize, _Decal3ClipFalloff);
-            CompositeDecal(o, decalTexture, decalsMask, _Decal3MaskChannel, _Decal3MaskStrength, _Decal3UseEmission, _Decal3EmissionStrength);
+            CompositeDecal(o, decalTexture, decalsMask, _Decal3MaskChannel, _Decal3MaskStrength, _Decal3UseEmission, _Decal3EmissionStrength, _Decal3MultiplyByAlbedo);
         }
         #endif
     }

--- a/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/Toon/v2/Main.orlsource
+++ b/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/Toon/v2/Main.orlsource
@@ -3,7 +3,7 @@
     UI_MainHeader("# Main Settings", Int) = 1
     UI_ToonDocs("[This shader has documentation](https://shaders.orels.sh/docs/toon)", Int) = 0
     _Color("Main Color", Color) = (1, 1, 1, 1)
-    _BackfaceColor("Backface Color %ShowIf(_CullMode != 2)", Color) = (1, 1, 1, 1)
+    _BackfaceColor("Backface Color %ShowIf", Color) = (1, 1, 1, 1)
     _BackfaceAlbedoTint("Backface Albedo Tint", Range(0,1)) = 1
     [ToggleUI]_TintByVertexColor("Tint By Vertex Color", Int) = 0
     _MainTex("Albedo", 2D) = "white" {}
@@ -14,6 +14,9 @@
     _Hue("Hue", Range(0,1)) = 0
     _Saturation("Saturation", Range(-1,1)) = 0
     _Value("Value", Range(-1,1)) = 0
+
+    UI_VRCLightVolumesHeader("# VRC Light Volumes", Int) = 0
+    [Toggle(VRCLIGHTVOLUMES)]_VRCLightVolumesEnabled("Enable VRC Light Volumes", Int) = 1
 }
 
 %ShaderDefines()

--- a/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/Toon/v2/Shading.orlsource
+++ b/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/Toon/v2/Shading.orlsource
@@ -83,16 +83,25 @@
 
 %ModuleLighting("ToonShadingLightingIndirect")
 {
-    void ToonShadingLightingIndirect(SurfaceData o, MeshData d, inout half3 indirectDiffuse)
+    void ToonShadingLightingIndirect(SurfaceData o, MeshData d, inout half3 indirectDiffuse, float3 lightDir)
     {
-        half3 L0 = float3(unity_SHAr.w, unity_SHAg.w, unity_SHAb.w);
-        half3 L0L2 = half3(unity_SHBr.z, unity_SHBg.z, unity_SHBb.z) / 3.0;
-        L0 = L0+L0L2;
+        #if defined(_INTEGRATE_CUSTOMPROBES)
+        {
+            %CustomProbesFunctions
+        }
+        #else
+        {
+            half3 L0 = float3(unity_SHAr.w, unity_SHAg.w, unity_SHAb.w);
+            half3 L0L2 = half3(unity_SHBr.z, unity_SHBg.z, unity_SHBb.z) / 3.0;
+            L0 = L0+L0L2;
 
-        float3 normal = _IgnoreLightprobeNormal ? float3(0, 0.5, 0) : o.WorldNormal;
+            float3 normal = _IgnoreLightprobeNormal ? float3(0, 0.5, 0) : o.WorldNormal;
+
+            indirectDiffuse = max(0, GetNonLinearSH(L0, unity_SHAr, unity_SHAg, unity_SHAb, normal));
+            indirectDiffuse += SHEvalLinearL2(float4(normal, 1));
+        }
+        #endif
         
-        indirectDiffuse = max(0, GetNonLinearSH(L0, unity_SHAr, unity_SHAg, unity_SHAb, normal));
-        indirectDiffuse += SHEvalLinearL2(float4(normal, 1));
         if (!_OffsetRampByOcclusion)
         {
             indirectDiffuse *= o.Occlusion;

--- a/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/VRCLightVolumes.orlsource
+++ b/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/VRCLightVolumes.orlsource
@@ -1,0 +1,469 @@
+%Properties()
+{
+    UI_VRCLightVolumesHeader("# VRC Light Volumes", Int) = 0
+    [Toggle(VRCLIGHTVOLUMES)]_VRCLightVolumesEnabled("Enable VRC Light Volumes", Int) = 0
+}
+
+%Variables()
+{
+    // Are Light Volumes enabled on scene?
+    float _UdonLightVolumeEnabled;
+
+    // All volumes count in scene
+    float _UdonLightVolumeCount;
+
+    // How volumes edge blending
+    float _UdonLightVolumeBlend;
+
+    // Should volumes be blended with lightprobes?
+    float _UdonLightVolumeProbesBlend;
+
+    // Should volumes be blended with lightprobes?
+    float _UdonLightVolumeSharpBounds;
+
+    // Rotation types: 0 - Fixed, 1 - Y Axis, 2 - Free
+    float _UdonLightVolumeRotationType[256];
+
+    // Fixed rotation:   A - WorldMin             B - WorldMax
+    // Y Axis rotation:  A - BoundsCenter | SinY  B - InvBoundsSize | CosY
+    // Free rotation:    A - 0                    B - InvBoundsSize
+    float4 _UdonLightVolumeDataA[256];
+    float4 _UdonLightVolumeDataB[256];
+
+    // Used with free rotation, World to Local (-0.5, 0.5) UVW Matrix
+    float4x4 _UdonLightVolumeInvWorldMatrix[256];
+
+    // AABB Bounds of islands on the 3D Texture atlas
+    float4 _UdonLightVolumeUvwMin[768];
+    float4 _UdonLightVolumeUvwMax[768];
+}
+
+%AdditionalSurfaceData()
+{
+    #if defined(VRCLIGHTVOLUMES)
+    float3 VRCLV_L0;
+    float3 VRCLV_L1r;
+    float3 VRCLV_L1g;
+    float3 VRCLV_L1b;
+    #endif
+}
+
+%Textures()
+{
+    TEXTURE3D(_UdonLightVolume);
+    SAMPLER(sampler_UdonLightVolume);
+}
+
+%ShaderFeatures()
+{
+    #pragma shader_feature_local_fragment VRCLIGHTVOLUMES
+}
+
+%ShaderDefines()
+{
+    #if defined(VRCLIGHTVOLUMES)
+        #define _INTEGRATE_CUSTOMPROBES
+    #endif
+}
+
+%CustomProbes("VRCLightVolumesCustomProbes")
+{
+    void VRCLightVolumesCustomProbes(inout SurfaceData o, MeshData d, inout half3 indirectDiffuse)
+    {
+        #if defined(VRCLIGHTVOLUMES)
+        
+        // Custom Probes
+        float3 L0, L1r, L1g, L1b;
+        LightVolumeSH(d.worldSpacePosition, L0, L1r, L1g, L1b);
+        o.VRCLV_L0 = L0;
+        o.VRCLV_L1r = L1r;
+        o.VRCLV_L1g = L1g;
+        o.VRCLV_L1b = L1b;
+
+        #if defined(NONLINEAR_SH)
+        {
+            indirectDiffuse = max(0, GetNonLinearSH(L0, L1r, L1g, L1b, o.Normal));
+        }
+        #else
+        {
+            indirectDiffuse = LightVolumeEvaluate(o.Normal, L0, L1r, L1g, L1b);   
+        }
+        #endif
+        
+        #endif
+    }
+}
+
+%CustomProbesBakedSpecular("VRCLightVolumesCustomProbesBakedSpecular")
+{
+    void VRCLightVolumesCustomProbesBakedSpecular(SurfaceData o, MeshData d, inout half3 indirectSpecular, inout half3 bakedSpecularColor, inout half3 bakedDominantDirection)
+    {
+        #if defined(VRCLIGHTVOLUMES)
+        bakedSpecularColor = o.VRCLV_L0;
+        bakedDominantDirection = o.VRCLV_L1r.xyz + o.VRCLV_L1g.xyz + o.VRCLV_L1b.xyz;
+        #endif
+    }
+}
+
+%PassFunctions()
+{
+    // Below is the integration CGINC from the VRCLightVolumes project
+    // https://github.com/REDSIM/VRCLightVolumes
+
+    // Linear single SH L1 channel evaluation
+    float LV_EvaluateSH(float L0, float3 L1, float3 n) {
+        L1 = L1 / 2;
+        float L1length = length(L1);
+        if (L1length > 0.0 && L0 > 0.0)
+        {
+            float k = min(L0 / L1length, 1.13);
+            L1 *= k;
+        }
+
+        return L0 + dot(L1, n);
+    }
+
+    // AABB intersection check
+    bool LV_PointAABB(float3 pos, float3 min, float3 max) {
+        return all(pos >= min && pos <= max);
+    }
+
+    // Checks if local UVW point is in bounds from -0.5 to +0.5
+    bool LV_PointLocalAABB(float3 localUVW){
+        return all(abs(localUVW) <= 0.5);
+    }
+
+    // Calculates Island UVW for Fixed Rotation Mode
+    float3 LV_IslandFromFixedVolume(int volumeID, int texID, float3 worldPos){
+        // World bounds
+        float3 worldMin = _UdonLightVolumeDataA[volumeID].xyz;
+        float3 worldMax = _UdonLightVolumeDataB[volumeID].xyz;
+        // UVW bounds
+        int uvwID = volumeID * 3 + texID;
+        float3 uvwMin = _UdonLightVolumeUvwMin[uvwID].xyz;
+        float3 uvwMax = _UdonLightVolumeUvwMax[uvwID].xyz;
+        // Ramapping world bounds to UVW bounds
+        return clamp(uvwMin + (worldPos - worldMin) * (uvwMax - uvwMin) / (worldMax - worldMin), uvwMin, uvwMax);
+    }
+
+    // Calculates local UVW for Y Axis rotation mode
+    float3 LV_LocalFromYAxisVolume(int volumeID, float3 worldPos){
+        // Bounds and rotation data
+        float3 invBoundsSize = _UdonLightVolumeDataB[volumeID].xyz;
+        float3 boundsCenter = _UdonLightVolumeDataA[volumeID].xyz;
+        float sinY = _UdonLightVolumeDataA[volumeID].w;
+        float cosY = _UdonLightVolumeDataB[volumeID].w;
+        // Ramapping world bounds to UVW bounds
+        float3 p = worldPos - boundsCenter;
+        float localX = p.x * cosY - p.z * sinY;
+        float localZ = p.x * sinY + p.z * cosY;
+        float localY = p.y;
+        return float3(localX, localY, localZ) * invBoundsSize;
+    }
+
+    // Calculates local UVW for Free rotation mode
+    float3 LV_LocalFromFreeVolume(int volumeID, float3 worldPos) {
+        return mul(_UdonLightVolumeInvWorldMatrix[volumeID], float4(worldPos, 1.0)).xyz;
+    }
+
+    // Calculates Island UVW from local UVW
+    float3 LV_LocalToIsland(int volumeID, int texID, float3 localUVW){
+        // UVW bounds
+        int uvwID = volumeID * 3 + texID;
+        float3 uvwMin = _UdonLightVolumeUvwMin[uvwID].xyz;
+        float3 uvwMax = _UdonLightVolumeUvwMax[uvwID].xyz;
+        // Ramapping world bounds to UVW bounds
+        return clamp(lerp(uvwMin, uvwMax, localUVW + 0.5), uvwMin, uvwMax);
+    }
+
+    // Default light probes SH components
+    void LV_SampleLightProbe(out float3 L0, out float3 L1r, out float3 L1g, out float3 L1b) {
+        L0 = float3(unity_SHAr.w, unity_SHAg.w, unity_SHAb.w);
+        L1r = unity_SHAr.xyz;
+        L1g = unity_SHAg.xyz;
+        L1b = unity_SHAb.xyz;
+    }
+
+    // Samples 3 SH textures and packing them into L1 channels
+    void LV_SampleLightVolumeTex(float3 uvw0, float3 uvw1, float3 uvw2, out float3 L0, out float3 L1r, out float3 L1g, out float3 L1b) {
+        // Sampling 3D Atlas
+        float4 tex0 = SAMPLE_TEXTURE3D(_UdonLightVolume, sampler_UdonLightVolume, uvw0);
+        float4 tex1 = SAMPLE_TEXTURE3D(_UdonLightVolume, sampler_UdonLightVolume, uvw1);
+        float4 tex2 = SAMPLE_TEXTURE3D(_UdonLightVolume, sampler_UdonLightVolume, uvw2);
+        // Packing final data
+        L0 = tex0.rgb;
+        L1r = float3(tex1.r, tex2.r, tex0.a);
+        L1g = float3(tex1.g, tex2.g, tex1.a);
+        L1b = float3(tex1.b, tex2.b, tex2.a);
+    }
+
+    // Faster than smoothstep
+    float LV_FastSmooth(float x) {
+        return x * x * (3.0 - 2.0 * x);
+    }
+
+    // Corrects exposure, shadows, mids and highlights
+    float3 LV_SimpleColorCorrection(float3 color, float exposure, float shadowGain, float midGain, float highlightGain) {
+        color *= exposure;
+        float luma = dot(color, float3(0.2126, 0.7152, 0.0722));
+        float shadowMask = LV_FastSmooth(saturate((0.4 - luma) * 2.5)); // 0.4 and 0.6 are for smoother tones overlap
+        float highlightMask = LV_FastSmooth(saturate((luma - 0.6) * 2.5)); // 2.5f is actually 1/0.4
+        float midMask = 1.0 - shadowMask - highlightMask;
+        float gain = shadowMask * shadowGain + midMask * midGain + highlightMask * highlightGain;
+        return color * gain;
+    }
+
+    // Bounds mask
+    float LV_BoundsMask(float3 pos, float3 minBounds, float3 maxBounds, float edgeSmooth) {
+        float3 distToMin = (pos - minBounds) / edgeSmooth;
+        float3 distToMax = (maxBounds - pos) / edgeSmooth;
+        float3 fade = saturate(min(distToMin, distToMax));
+        return fade.x * fade.y * fade.z;
+    }
+
+    // Bounds mask, but for rotated in world space, using local UVW
+    float LV_BoundsMaskOBB(float3 localUVW, float3 edgeSmooth, float3 invBoundsScale) {
+        float3 edgeSmoothLocal = edgeSmooth * invBoundsScale;
+        float3 distToMin = (localUVW + 0.5) / edgeSmoothLocal;
+        float3 distToMax = (0.5 - localUVW) / edgeSmoothLocal;
+        float3 fade = saturate(min(distToMin, distToMax));
+        return fade.x * fade.y * fade.z;
+    }
+
+    // Calculate Light Volume Color based on all SH components provided
+    float3 LightVolumeEvaluate(float3 worldNormal, float3 L0, float3 L1r, float3 L1g, float3 L1b) {
+        return float3(LV_EvaluateSH(L0.r, L1r, worldNormal), LV_EvaluateSH(L0.g, L1g, worldNormal), LV_EvaluateSH(L0.b, L1b, worldNormal));
+    }
+
+    // Calculates SH components based on world position and world normal
+    void LightVolumeSH(float3 worldPos, out float3 L0, out float3 L1r, out float3 L1g, out float3 L1b) {
+
+        // Fallback to default light probes if Light Volume are not enabled
+        if (!_UdonLightVolumeEnabled || _UdonLightVolumeCount == 0) {
+            LV_SampleLightProbe(L0, L1r, L1g, L1b);
+            return;
+        }
+        
+        int volumeID_A = -1; // Main, dominant volume ID
+        int volumeID_B = -1; // Secondary volume ID to blend main with
+        
+        int rotType_A = 0; // Main Rot Type
+        int rotType_B = 0; // Secondary Rot Type
+        
+        float3 localUVW; // Last local UVW to use in disabled Light Probes mode
+        float3 localUVW_A; // Main local UVW for Y Axis and Free roattions
+        float3 localUVW_B; // Secondary local UVW
+        
+        
+        // Iterating through all light volumes with simplified algorithm requiring Light Volumes to be sorted by weight in descending order
+        for (int id = 0; id < _UdonLightVolumeCount; id++) {
+            
+            if (_UdonLightVolumeRotationType[id] == 0) { // Fixed Rotation
+                
+                // Intersection test
+                if (LV_PointAABB(worldPos, _UdonLightVolumeDataA[id].xyz, _UdonLightVolumeDataB[id].xyz)) {
+                    if (volumeID_A != -1) { 
+                        volumeID_B = id; 
+                        break; 
+                    } else {
+                        volumeID_A = id;
+                    }
+                }
+                
+            } else if (_UdonLightVolumeRotationType[id] == 1) { // Y Axis Rotation
+                
+                // Transform to Local UVW
+                localUVW = LV_LocalFromYAxisVolume(id, worldPos);
+                
+                //Intersection test
+                if (LV_PointLocalAABB(localUVW)) {
+                    if (volumeID_A != -1) { 
+                        volumeID_B = id; 
+                        localUVW_B = localUVW;
+                        rotType_B = 1;
+                        break; 
+                    } else {
+                        volumeID_A = id;
+                        localUVW_A = localUVW;
+                        rotType_A = 1;
+                    }
+                }
+                
+            } else { // Free Rotation
+                
+                // Transform to Local UVW
+                localUVW = LV_LocalFromFreeVolume(id, worldPos);
+                
+                //Intersection test
+                if (LV_PointLocalAABB(localUVW)) {
+                    if (volumeID_A != -1) { 
+                        volumeID_B = id; 
+                        localUVW_B = localUVW;
+                        rotType_B = 2;
+                        break; 
+                    } else {
+                        volumeID_A = id;
+                        localUVW_A = localUVW;
+                        rotType_A = 2;
+                    }
+                }
+                
+            }
+            
+        }
+            
+        // If no volumes found, using Fallback
+        if (volumeID_A == -1) {
+            
+            if (_UdonLightVolumeProbesBlend){ // Sample Light Probes Enabled
+                
+                LV_SampleLightProbe(L0, L1r, L1g, L1b); // Sample Lioght Probes as Fallback
+                return;
+                
+            } else { // Sample Light Probes Disabled, sample LAST volume instead
+                
+                // Volume A UVWs
+                float3 uvw0, uvw1, uvw2;
+                int id = _UdonLightVolumeCount - 1;
+                
+                // Volume A UVWs depending on Rotation Type
+                if (_UdonLightVolumeRotationType[id] == 0) {
+                    uvw0 = LV_IslandFromFixedVolume(id, 0, worldPos);
+                    uvw1 = LV_IslandFromFixedVolume(id, 1, worldPos);
+                    uvw2 = LV_IslandFromFixedVolume(id, 2, worldPos);
+                } else {
+                    uvw0 = LV_LocalToIsland(id, 0, localUVW);
+                    uvw1 = LV_LocalToIsland(id, 1, localUVW);
+                    uvw2 = LV_LocalToIsland(id, 2, localUVW);
+                }
+                
+                LV_SampleLightVolumeTex(uvw0, uvw1, uvw2, L0, L1r, L1g, L1b); // Sample Last Volume as fallback
+                return;
+                
+            }
+        }
+            
+        // Mask to blend volume
+        float mask;
+        if (rotType_A == 0) {
+            mask = LV_BoundsMask(worldPos, _UdonLightVolumeDataA[volumeID_A].xyz, _UdonLightVolumeDataB[volumeID_A].xyz, _UdonLightVolumeBlend);
+        } else {
+            mask = LV_BoundsMaskOBB(localUVW_A, _UdonLightVolumeBlend, _UdonLightVolumeDataB[volumeID_A].xyz);
+        }
+        
+        if (mask == 1) { // Only sample Volume A
+            
+
+            // Volume A UVWs
+            float3 uvw0, uvw1, uvw2;
+            
+            // Volume A UVWs depending on Rotation Type
+            if (rotType_A == 0) {
+                uvw0 = LV_IslandFromFixedVolume(volumeID_A, 0, worldPos);
+                uvw1 = LV_IslandFromFixedVolume(volumeID_A, 1, worldPos);
+                uvw2 = LV_IslandFromFixedVolume(volumeID_A, 2, worldPos);
+            } else {
+                uvw0 = LV_LocalToIsland(volumeID_A, 0, localUVW_A);
+                uvw1 = LV_LocalToIsland(volumeID_A, 1, localUVW_A);
+                uvw2 = LV_LocalToIsland(volumeID_A, 2, localUVW_A);
+            }
+            
+            LV_SampleLightVolumeTex(uvw0, uvw1, uvw2, L0, L1r, L1g, L1b); // Sample Volume A
+            return;
+            
+        } else { // Only blend mask for pixels in the smoothed edges region
+                
+            // SH Components
+            float3 L0_A, L1r_A, L1g_A, L1b_A, L0_B, L1r_B, L1g_B, L1b_B, uvw0_A, uvw1_A, uvw2_A;
+            
+            if (volumeID_B == -1) { // Blending Volume A and Light Probes
+                    
+                // Volume A UVWs depending on Rotation Type
+                if (rotType_A == 0) {
+                    uvw0_A = LV_IslandFromFixedVolume(volumeID_A, 0, worldPos);
+                    uvw1_A = LV_IslandFromFixedVolume(volumeID_A, 1, worldPos);
+                    uvw2_A = LV_IslandFromFixedVolume(volumeID_A, 2, worldPos);
+                } else {
+                    uvw0_A = LV_LocalToIsland(volumeID_A, 0, localUVW_A);
+                    uvw1_A = LV_LocalToIsland(volumeID_A, 1, localUVW_A);
+                    uvw2_A = LV_LocalToIsland(volumeID_A, 2, localUVW_A);
+                }
+                    
+                LV_SampleLightVolumeTex(uvw0_A, uvw1_A, uvw2_A, L0_A, L1r_A, L1g_A, L1b_A); // Sample Volume A
+                
+                if (_UdonLightVolumeSharpBounds){ // If no need to blend with light probes
+                    L0 = L0_A;
+                    L1r = L1r_A;
+                    L1g = L1g_A;
+                    L1b = L1b_A;
+                    return;
+                }
+                
+                if (_UdonLightVolumeProbesBlend){ // Sample Light Probes Enabled
+                
+                    LV_SampleLightProbe(L0_B, L1r_B, L1g_B, L1b_B); // Sample Light Probes B
+                
+                } else { // Sample Light Probes Disabled, sample LAST volume instead
+                
+                    // Volume A UVWs
+                    float3 uvw0_B, uvw1_B, uvw2_B;
+                    int id = _UdonLightVolumeCount - 1;
+                
+                    // Volume A UVWs depending on Rotation Type
+                    if (_UdonLightVolumeRotationType[id] == 0) {
+                        uvw0_B = LV_IslandFromFixedVolume(id, 0, worldPos);
+                        uvw1_B = LV_IslandFromFixedVolume(id, 1, worldPos);
+                        uvw2_B = LV_IslandFromFixedVolume(id, 2, worldPos);
+                    } else {
+                        uvw0_B = LV_LocalToIsland(id, 0, localUVW);
+                        uvw1_B = LV_LocalToIsland(id, 1, localUVW);
+                        uvw2_B = LV_LocalToIsland(id, 2, localUVW);
+                    }
+                
+                    LV_SampleLightVolumeTex(uvw0_B, uvw1_B, uvw2_B, L0_B, L1r_B, L1g_B, L1b_B); // Sample Last Volume as fallback
+                
+                }
+                    
+            } else { // Blending Volume A and Volume B
+                
+                // UVW B
+                float3 uvw0_B, uvw1_B, uvw2_B;
+                
+                // Volume A UVWs
+                if (rotType_A == 0) {
+                    uvw0_A = LV_IslandFromFixedVolume(volumeID_A, 0, worldPos);
+                    uvw1_A = LV_IslandFromFixedVolume(volumeID_A, 1, worldPos);
+                    uvw2_A = LV_IslandFromFixedVolume(volumeID_A, 2, worldPos);
+                } else {
+                    uvw0_A = LV_LocalToIsland(volumeID_A, 0, localUVW_A);
+                    uvw1_A = LV_LocalToIsland(volumeID_A, 1, localUVW_A);
+                    uvw2_A = LV_LocalToIsland(volumeID_A, 2, localUVW_A);
+                }
+                
+                // Volume B UVWs
+                if (rotType_B == 0) {
+                    uvw0_B = LV_IslandFromFixedVolume(volumeID_B, 0, worldPos);
+                    uvw1_B = LV_IslandFromFixedVolume(volumeID_B, 1, worldPos);
+                    uvw2_B = LV_IslandFromFixedVolume(volumeID_B, 2, worldPos);
+                } else {
+                    uvw0_B = LV_LocalToIsland(volumeID_B, 0, localUVW_B);
+                    uvw1_B = LV_LocalToIsland(volumeID_B, 1, localUVW_B);
+                    uvw2_B = LV_LocalToIsland(volumeID_B, 2, localUVW_B);
+                }
+                
+                LV_SampleLightVolumeTex(uvw0_A, uvw1_A, uvw2_A, L0_A, L1r_A, L1g_A, L1b_A); // Sample Volume A
+                LV_SampleLightVolumeTex(uvw0_B, uvw1_B, uvw2_B, L0_B, L1r_B, L1g_B, L1b_B); // Sample Volume B
+                
+            }
+            
+            // Lerping SH components
+            L0 =  lerp(L0_B,  L0_A,  mask);
+            L1r = lerp(L1r_B, L1r_A, mask);
+            L1g = lerp(L1g_B, L1g_A, mask);
+            L1b = lerp(L1b_B, L1b_A, mask);
+            return;
+
+        }
+
+    }
+}

--- a/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/VRCLightVolumes.orlsource
+++ b/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/VRCLightVolumes.orlsource
@@ -1,3 +1,28 @@
+// Below is the integration CGINC from the VRCLightVolumes project
+// https://github.com/REDSIM/VRCLightVolumes
+// MIT License
+
+// Copyright (c) 2025 RED_SIM
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+
 %Properties()
 {
     UI_VRCLightVolumesHeader("# VRC Light Volumes", Int) = 0
@@ -126,9 +151,6 @@
 
 %PassFunctions()
 {
-    // Below is the integration CGINC from the VRCLightVolumes project
-    // https://github.com/REDSIM/VRCLightVolumes
-
     // Rotates vector by quaternion
     float3 LV_MultiplyVectorByQuaternion(float3 v, float4 q) {
         float3 t = 2.0 * cross(q.xyz, v);

--- a/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/VRCLightVolumes.orlsource
+++ b/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/VRCLightVolumes.orlsource
@@ -12,6 +12,12 @@
     // All volumes count in scene
     float _UdonLightVolumeCount;
 
+    // Additive volumes max overdraw count
+    float _UdonLightVolumeAdditiveMaxOverdraw;
+
+    // Additive volumes count
+    float _UdonLightVolumeAdditiveCount;
+
     // How volumes edge blending
     float _UdonLightVolumeBlend;
 
@@ -21,21 +27,27 @@
     // Should volumes be blended with lightprobes?
     float _UdonLightVolumeSharpBounds;
 
-    // Rotation types: 0 - Fixed, 1 - Y Axis, 2 - Free
-    float _UdonLightVolumeRotationType[256];
-
-    // Fixed rotation:   A - WorldMin             B - WorldMax
-    // Y Axis rotation:  A - BoundsCenter | SinY  B - InvBoundsSize | CosY
-    // Free rotation:    A - 0                    B - InvBoundsSize
-    float4 _UdonLightVolumeDataA[256];
-    float4 _UdonLightVolumeDataB[256];
-
-    // Used with free rotation, World to Local (-0.5, 0.5) UVW Matrix
+    // World to Local (-0.5, 0.5) UVW Matrix
     float4x4 _UdonLightVolumeInvWorldMatrix[256];
+
+    // L1 SH components rotation (relative to baked rotataion)
+    float4 _UdonLightVolumeRotation[256];
+
+    // If we actually need to rotate L1 components at all
+    float _UdonLightVolumeIsRotated[256];
+
+    // Is this light volume in additive mode?
+    float _UdonLightVolumeAdditive[256];
+
+    // Value that is needed to smoothly blend volumes ( BoundsScale / edgeSmooth )
+    float3 _UdonLightVolumeInvLocalEdgeSmooth[256];
 
     // AABB Bounds of islands on the 3D Texture atlas
     float4 _UdonLightVolumeUvwMin[768];
     float4 _UdonLightVolumeUvwMax[768];
+
+    // Color multiplier
+    float4 _UdonLightVolumeColor[256];
 }
 
 %AdditionalSurfaceData()
@@ -66,30 +78,37 @@
     #endif
 }
 
-%CustomProbes("VRCLightVolumesCustomProbes")
+%CustomProbesSetup("VRCLightVolumesCustomProbesSetup")
 {
-    void VRCLightVolumesCustomProbes(inout SurfaceData o, MeshData d, inout half3 indirectDiffuse)
+    void VRCLightVolumesCustomProbesSetup(MeshData d, inout SurfaceData o)
     {
         #if defined(VRCLIGHTVOLUMES)
-        
-        // Custom Probes
-        float3 L0, L1r, L1g, L1b;
-        LightVolumeSH(d.worldSpacePosition, L0, L1r, L1g, L1b);
-        o.VRCLV_L0 = L0;
-        o.VRCLV_L1r = L1r;
-        o.VRCLV_L1g = L1g;
-        o.VRCLV_L1b = L1b;
-
-        #if defined(NONLINEAR_SH)
         {
-            indirectDiffuse = max(0, GetNonLinearSH(L0, L1r, L1g, L1b, o.Normal));
-        }
-        #else
-        {
-            indirectDiffuse = LightVolumeEvaluate(o.Normal, L0, L1r, L1g, L1b);   
+            float3 L0, L1r, L1g, L1b;
+            LightVolumeSH(d.worldSpacePosition, L0, L1r, L1g, L1b);
+            o.VRCLV_L0 = L0;
+            o.VRCLV_L1r = L1r;
+            o.VRCLV_L1g = L1g;
+            o.VRCLV_L1b = L1b;
         }
         #endif
-        
+    }
+}
+
+%CustomProbes("VRCLightVolumesCustomProbes")
+{
+    void VRCLightVolumesCustomProbes(SurfaceData o, MeshData d, inout half3 indirectDiffuse)
+    {
+        // Custom Probes
+        #if defined(VRCLIGHTVOLUMES)
+        {
+            #if defined(ORL_LIGHTING_MODEL_TOON_V2)
+            {
+                o.Normal = _IgnoreLightprobeNormal ? float3(0, 0.5, 0) : o.WorldNormal;
+            }
+            #endif
+            indirectDiffuse = LightVolumeEvaluate(o.Normal, o.VRCLV_L0, o.VRCLV_L1r, o.VRCLV_L1g, o.VRCLV_L1b);   
+        }
         #endif
     }
 }
@@ -110,22 +129,10 @@
     // Below is the integration CGINC from the VRCLightVolumes project
     // https://github.com/REDSIM/VRCLightVolumes
 
-    // Linear single SH L1 channel evaluation
-    float LV_EvaluateSH(float L0, float3 L1, float3 n) {
-        L1 = L1 / 2;
-        float L1length = length(L1);
-        if (L1length > 0.0 && L0 > 0.0)
-        {
-            float k = min(L0 / L1length, 1.13);
-            L1 *= k;
-        }
-
-        return L0 + dot(L1, n);
-    }
-
-    // AABB intersection check
-    bool LV_PointAABB(float3 pos, float3 min, float3 max) {
-        return all(pos >= min && pos <= max);
+    // Rotates vector by quaternion
+    float3 LV_MultiplyVectorByQuaternion(float3 v, float4 q) {
+        float3 t = 2.0 * cross(q.xyz, v);
+        return v + q.w * t + cross(q.xyz, t);
     }
 
     // Checks if local UVW point is in bounds from -0.5 to +0.5
@@ -133,36 +140,8 @@
         return all(abs(localUVW) <= 0.5);
     }
 
-    // Calculates Island UVW for Fixed Rotation Mode
-    float3 LV_IslandFromFixedVolume(int volumeID, int texID, float3 worldPos){
-        // World bounds
-        float3 worldMin = _UdonLightVolumeDataA[volumeID].xyz;
-        float3 worldMax = _UdonLightVolumeDataB[volumeID].xyz;
-        // UVW bounds
-        int uvwID = volumeID * 3 + texID;
-        float3 uvwMin = _UdonLightVolumeUvwMin[uvwID].xyz;
-        float3 uvwMax = _UdonLightVolumeUvwMax[uvwID].xyz;
-        // Ramapping world bounds to UVW bounds
-        return clamp(uvwMin + (worldPos - worldMin) * (uvwMax - uvwMin) / (worldMax - worldMin), uvwMin, uvwMax);
-    }
-
-    // Calculates local UVW for Y Axis rotation mode
-    float3 LV_LocalFromYAxisVolume(int volumeID, float3 worldPos){
-        // Bounds and rotation data
-        float3 invBoundsSize = _UdonLightVolumeDataB[volumeID].xyz;
-        float3 boundsCenter = _UdonLightVolumeDataA[volumeID].xyz;
-        float sinY = _UdonLightVolumeDataA[volumeID].w;
-        float cosY = _UdonLightVolumeDataB[volumeID].w;
-        // Ramapping world bounds to UVW bounds
-        float3 p = worldPos - boundsCenter;
-        float localX = p.x * cosY - p.z * sinY;
-        float localZ = p.x * sinY + p.z * cosY;
-        float localY = p.y;
-        return float3(localX, localY, localZ) * invBoundsSize;
-    }
-
-    // Calculates local UVW for Free rotation mode
-    float3 LV_LocalFromFreeVolume(int volumeID, float3 worldPos) {
+    // Calculates local UVW using volume ID
+    float3 LV_LocalFromVolume(int volumeID, float3 worldPos) {
         return mul(_UdonLightVolumeInvWorldMatrix[volumeID], float4(worldPos, 1.0)).xyz;
     }
 
@@ -176,6 +155,27 @@
         return clamp(lerp(uvwMin, uvwMax, localUVW + 0.5), uvwMin, uvwMax);
     }
 
+    // Samples 3 SH textures and packing them into L1 channels
+    void LV_SampleLightVolumeTex(float3 uvw0, float3 uvw1, float3 uvw2, out float3 L0, out float3 L1r, out float3 L1g, out float3 L1b) {
+        // Sampling 3D Atlas
+        float4 tex0 = SAMPLE_TEXTURE3D_LOD(_UdonLightVolume, sampler_UdonLightVolume, uvw0, 0);
+        float4 tex1 = SAMPLE_TEXTURE3D_LOD(_UdonLightVolume, sampler_UdonLightVolume, uvw1, 0);
+        float4 tex2 = SAMPLE_TEXTURE3D_LOD(_UdonLightVolume, sampler_UdonLightVolume, uvw2, 0);
+        // Packing final data
+        L0 = tex0.rgb;
+        L1r = float3(tex1.r, tex2.r, tex0.a);
+        L1g = float3(tex1.g, tex2.g, tex1.a);
+        L1b = float3(tex1.b, tex2.b, tex2.a);
+    }
+
+    // Bounds mask for a volume rotated in world space, using local UVW
+    float LV_BoundsMask(float3 localUVW, float3 invLocalEdgeSmooth) {
+        float3 distToMin = (localUVW + 0.5) * invLocalEdgeSmooth;
+        float3 distToMax = (0.5 - localUVW) * invLocalEdgeSmooth;
+        float3 fade = saturate(min(distToMin, distToMax));
+        return fade.x * fade.y * fade.z;
+    }
+
     // Default light probes SH components
     void LV_SampleLightProbe(out float3 L0, out float3 L1r, out float3 L1g, out float3 L1b) {
         L0 = float3(unity_SHAr.w, unity_SHAg.w, unity_SHAb.w);
@@ -184,60 +184,51 @@
         L1b = unity_SHAb.xyz;
     }
 
-    // Samples 3 SH textures and packing them into L1 channels
-    void LV_SampleLightVolumeTex(float3 uvw0, float3 uvw1, float3 uvw2, out float3 L0, out float3 L1r, out float3 L1g, out float3 L1b) {
-        // Sampling 3D Atlas
-        float4 tex0 = SAMPLE_TEXTURE3D(_UdonLightVolume, sampler_UdonLightVolume, uvw0);
-        float4 tex1 = SAMPLE_TEXTURE3D(_UdonLightVolume, sampler_UdonLightVolume, uvw1);
-        float4 tex2 = SAMPLE_TEXTURE3D(_UdonLightVolume, sampler_UdonLightVolume, uvw2);
-        // Packing final data
-        L0 = tex0.rgb;
-        L1r = float3(tex1.r, tex2.r, tex0.a);
-        L1g = float3(tex1.g, tex2.g, tex1.a);
-        L1b = float3(tex1.b, tex2.b, tex2.a);
+    // Linear single SH L1 channel evaluation
+    float LV_EvaluateSH(float L0, float3 L1, float3 n) {
+        return L0 + dot(L1, n);
     }
 
-    // Faster than smoothstep
-    float LV_FastSmooth(float x) {
-        return x * x * (3.0 - 2.0 * x);
+    // Samples a Volume with ID and Local UVW
+    void LV_SampleVolume(int id, float3 localUVW, out float3 L0, out float3 L1r, out float3 L1g, out float3 L1b) {
+        
+        // Additive UVW
+        float3 uvw0 = LV_LocalToIsland(id, 0, localUVW);
+        float3 uvw1 = LV_LocalToIsland(id, 1, localUVW);
+        float3 uvw2 = LV_LocalToIsland(id, 2, localUVW);
+                    
+        // Sample additive
+        LV_SampleLightVolumeTex(uvw0, uvw1, uvw2, L0, L1r, L1g, L1b);
+        
+        // Color correction
+        L0 = L0 * _UdonLightVolumeColor[id].rgb;
+        L1r = L1r * _UdonLightVolumeColor[id].r;
+        L1g = L1g * _UdonLightVolumeColor[id].g;
+        L1b = L1b * _UdonLightVolumeColor[id].b;
+        
+        // Rotate if needed
+        if (_UdonLightVolumeIsRotated[id] != 0) {
+            L1r = LV_MultiplyVectorByQuaternion(L1r, _UdonLightVolumeRotation[id]);
+            L1g = LV_MultiplyVectorByQuaternion(L1g, _UdonLightVolumeRotation[id]);
+            L1b = LV_MultiplyVectorByQuaternion(L1b, _UdonLightVolumeRotation[id]);
+        }
+                    
     }
 
-    // Corrects exposure, shadows, mids and highlights
-    float3 LV_SimpleColorCorrection(float3 color, float exposure, float shadowGain, float midGain, float highlightGain) {
-        color *= exposure;
-        float luma = dot(color, float3(0.2126, 0.7152, 0.0722));
-        float shadowMask = LV_FastSmooth(saturate((0.4 - luma) * 2.5)); // 0.4 and 0.6 are for smoother tones overlap
-        float highlightMask = LV_FastSmooth(saturate((luma - 0.6) * 2.5)); // 2.5f is actually 1/0.4
-        float midMask = 1.0 - shadowMask - highlightMask;
-        float gain = shadowMask * shadowGain + midMask * midGain + highlightMask * highlightGain;
-        return color * gain;
-    }
-
-    // Bounds mask
-    float LV_BoundsMask(float3 pos, float3 minBounds, float3 maxBounds, float edgeSmooth) {
-        float3 distToMin = (pos - minBounds) / edgeSmooth;
-        float3 distToMax = (maxBounds - pos) / edgeSmooth;
-        float3 fade = saturate(min(distToMin, distToMax));
-        return fade.x * fade.y * fade.z;
-    }
-
-    // Bounds mask, but for rotated in world space, using local UVW
-    float LV_BoundsMaskOBB(float3 localUVW, float3 edgeSmooth, float3 invBoundsScale) {
-        float3 edgeSmoothLocal = edgeSmooth * invBoundsScale;
-        float3 distToMin = (localUVW + 0.5) / edgeSmoothLocal;
-        float3 distToMax = (0.5 - localUVW) / edgeSmoothLocal;
-        float3 fade = saturate(min(distToMin, distToMax));
-        return fade.x * fade.y * fade.z;
-    }
-
-    // Calculate Light Volume Color based on all SH components provided
+    // Calculate Light Volume Color based on all SH components provided and the world normal
     float3 LightVolumeEvaluate(float3 worldNormal, float3 L0, float3 L1r, float3 L1g, float3 L1b) {
         return float3(LV_EvaluateSH(L0.r, L1r, worldNormal), LV_EvaluateSH(L0.g, L1g, worldNormal), LV_EvaluateSH(L0.b, L1b, worldNormal));
     }
 
-    // Calculates SH components based on world position and world normal
+    // Calculates SH components based on the world position
     void LightVolumeSH(float3 worldPos, out float3 L0, out float3 L1r, out float3 L1g, out float3 L1b) {
 
+        // Initializing output variables
+        L0  = float3(0, 0, 0);
+        L1r = float3(0, 0, 0);
+        L1g = float3(0, 0, 0);
+        L1b = float3(0, 0, 0);
+        
         // Fallback to default light probes if Light Volume are not enabled
         if (!_UdonLightVolumeEnabled || _UdonLightVolumeCount == 0) {
             LV_SampleLightProbe(L0, L1r, L1g, L1b);
@@ -246,223 +237,147 @@
         
         int volumeID_A = -1; // Main, dominant volume ID
         int volumeID_B = -1; // Secondary volume ID to blend main with
+
+        float3 localUVW   = float3(0, 0, 0); // Last local UVW to use in disabled Light Probes mode
+        float3 localUVW_A = float3(0, 0, 0); // Main local UVW for Y Axis and Free rotations
+        float3 localUVW_B = float3(0, 0, 0); // Secondary local UVW
         
-        int rotType_A = 0; // Main Rot Type
-        int rotType_B = 0; // Secondary Rot Type
+        // Are A and B volumes NOT found?
+        bool isNoA = true;
+        bool isNoB = true;
         
-        float3 localUVW; // Last local UVW to use in disabled Light Probes mode
-        float3 localUVW_A; // Main local UVW for Y Axis and Free roattions
-        float3 localUVW_B; // Secondary local UVW
+        // Additive volumes variables
+        int addVolumesCount = 0;
+        float3 L0_, L1r_, L1g_, L1b_;
         
+        int id = 0; // Loop iterator
         
         // Iterating through all light volumes with simplified algorithm requiring Light Volumes to be sorted by weight in descending order
-        for (int id = 0; id < _UdonLightVolumeCount; id++) {
-            
-            if (_UdonLightVolumeRotationType[id] == 0) { // Fixed Rotation
-                
-                // Intersection test
-                if (LV_PointAABB(worldPos, _UdonLightVolumeDataA[id].xyz, _UdonLightVolumeDataB[id].xyz)) {
-                    if (volumeID_A != -1) { 
-                        volumeID_B = id; 
-                        break; 
-                    } else {
-                        volumeID_A = id;
-                    }
-                }
-                
-            } else if (_UdonLightVolumeRotationType[id] == 1) { // Y Axis Rotation
-                
-                // Transform to Local UVW
-                localUVW = LV_LocalFromYAxisVolume(id, worldPos);
-                
-                //Intersection test
-                if (LV_PointLocalAABB(localUVW)) {
-                    if (volumeID_A != -1) { 
-                        volumeID_B = id; 
-                        localUVW_B = localUVW;
-                        rotType_B = 1;
-                        break; 
-                    } else {
-                        volumeID_A = id;
-                        localUVW_A = localUVW;
-                        rotType_A = 1;
-                    }
-                }
-                
-            } else { // Free Rotation
-                
-                // Transform to Local UVW
-                localUVW = LV_LocalFromFreeVolume(id, worldPos);
-                
-                //Intersection test
-                if (LV_PointLocalAABB(localUVW)) {
-                    if (volumeID_A != -1) { 
-                        volumeID_B = id; 
-                        localUVW_B = localUVW;
-                        rotType_B = 2;
-                        break; 
-                    } else {
-                        volumeID_A = id;
-                        localUVW_A = localUVW;
-                        rotType_A = 2;
-                    }
-                }
-                
+        [loop]
+        for (; id < _UdonLightVolumeAdditiveCount && addVolumesCount < _UdonLightVolumeAdditiveMaxOverdraw; id++) {
+            localUVW = LV_LocalFromVolume(id, worldPos);
+            if (LV_PointLocalAABB(localUVW)) { // Intersection test
+                LV_SampleVolume(id, localUVW, L0_, L1r_, L1g_, L1b_);
+                L0 += L0_;
+                L1r += L1r_;
+                L1g += L1g_;
+                L1b += L1b_;
+                addVolumesCount++;
             }
-            
-        }
-            
-        // If no volumes found, using Fallback
-        if (volumeID_A == -1) {
-            
-            if (_UdonLightVolumeProbesBlend){ // Sample Light Probes Enabled
-                
-                LV_SampleLightProbe(L0, L1r, L1g, L1b); // Sample Lioght Probes as Fallback
-                return;
-                
-            } else { // Sample Light Probes Disabled, sample LAST volume instead
-                
-                // Volume A UVWs
-                float3 uvw0, uvw1, uvw2;
-                int id = _UdonLightVolumeCount - 1;
-                
-                // Volume A UVWs depending on Rotation Type
-                if (_UdonLightVolumeRotationType[id] == 0) {
-                    uvw0 = LV_IslandFromFixedVolume(id, 0, worldPos);
-                    uvw1 = LV_IslandFromFixedVolume(id, 1, worldPos);
-                    uvw2 = LV_IslandFromFixedVolume(id, 2, worldPos);
-                } else {
-                    uvw0 = LV_LocalToIsland(id, 0, localUVW);
-                    uvw1 = LV_LocalToIsland(id, 1, localUVW);
-                    uvw2 = LV_LocalToIsland(id, 2, localUVW);
-                }
-                
-                LV_SampleLightVolumeTex(uvw0, uvw1, uvw2, L0, L1r, L1g, L1b); // Sample Last Volume as fallback
-                return;
-                
-            }
-        }
-            
-        // Mask to blend volume
-        float mask;
-        if (rotType_A == 0) {
-            mask = LV_BoundsMask(worldPos, _UdonLightVolumeDataA[volumeID_A].xyz, _UdonLightVolumeDataB[volumeID_A].xyz, _UdonLightVolumeBlend);
-        } else {
-            mask = LV_BoundsMaskOBB(localUVW_A, _UdonLightVolumeBlend, _UdonLightVolumeDataB[volumeID_A].xyz);
         }
         
-        if (mask == 1) { // Only sample Volume A
-            
-
-            // Volume A UVWs
-            float3 uvw0, uvw1, uvw2;
-            
-            // Volume A UVWs depending on Rotation Type
-            if (rotType_A == 0) {
-                uvw0 = LV_IslandFromFixedVolume(volumeID_A, 0, worldPos);
-                uvw1 = LV_IslandFromFixedVolume(volumeID_A, 1, worldPos);
-                uvw2 = LV_IslandFromFixedVolume(volumeID_A, 2, worldPos);
-            } else {
-                uvw0 = LV_LocalToIsland(volumeID_A, 0, localUVW_A);
-                uvw1 = LV_LocalToIsland(volumeID_A, 1, localUVW_A);
-                uvw2 = LV_LocalToIsland(volumeID_A, 2, localUVW_A);
+        [loop] // First, searching for volume A
+        for (id = _UdonLightVolumeAdditiveCount; id < _UdonLightVolumeCount; id++) {
+            localUVW = LV_LocalFromVolume(id, worldPos);
+            if (LV_PointLocalAABB(localUVW)) { // Intersection test
+                volumeID_A = id;
+                localUVW_A = localUVW;
+                isNoA = false;
+                break;
             }
-            
-            LV_SampleLightVolumeTex(uvw0, uvw1, uvw2, L0, L1r, L1g, L1b); // Sample Volume A
-            return;
-            
-        } else { // Only blend mask for pixels in the smoothed edges region
-                
-            // SH Components
-            float3 L0_A, L1r_A, L1g_A, L1b_A, L0_B, L1r_B, L1g_B, L1b_B, uvw0_A, uvw1_A, uvw2_A;
-            
-            if (volumeID_B == -1) { // Blending Volume A and Light Probes
-                    
-                // Volume A UVWs depending on Rotation Type
-                if (rotType_A == 0) {
-                    uvw0_A = LV_IslandFromFixedVolume(volumeID_A, 0, worldPos);
-                    uvw1_A = LV_IslandFromFixedVolume(volumeID_A, 1, worldPos);
-                    uvw2_A = LV_IslandFromFixedVolume(volumeID_A, 2, worldPos);
-                } else {
-                    uvw0_A = LV_LocalToIsland(volumeID_A, 0, localUVW_A);
-                    uvw1_A = LV_LocalToIsland(volumeID_A, 1, localUVW_A);
-                    uvw2_A = LV_LocalToIsland(volumeID_A, 2, localUVW_A);
-                }
-                    
-                LV_SampleLightVolumeTex(uvw0_A, uvw1_A, uvw2_A, L0_A, L1r_A, L1g_A, L1b_A); // Sample Volume A
-                
-                if (_UdonLightVolumeSharpBounds){ // If no need to blend with light probes
-                    L0 = L0_A;
-                    L1r = L1r_A;
-                    L1g = L1g_A;
-                    L1b = L1b_A;
-                    return;
-                }
-                
-                if (_UdonLightVolumeProbesBlend){ // Sample Light Probes Enabled
-                
-                    LV_SampleLightProbe(L0_B, L1r_B, L1g_B, L1b_B); // Sample Light Probes B
-                
-                } else { // Sample Light Probes Disabled, sample LAST volume instead
-                
-                    // Volume A UVWs
-                    float3 uvw0_B, uvw1_B, uvw2_B;
-                    int id = _UdonLightVolumeCount - 1;
-                
-                    // Volume A UVWs depending on Rotation Type
-                    if (_UdonLightVolumeRotationType[id] == 0) {
-                        uvw0_B = LV_IslandFromFixedVolume(id, 0, worldPos);
-                        uvw1_B = LV_IslandFromFixedVolume(id, 1, worldPos);
-                        uvw2_B = LV_IslandFromFixedVolume(id, 2, worldPos);
-                    } else {
-                        uvw0_B = LV_LocalToIsland(id, 0, localUVW);
-                        uvw1_B = LV_LocalToIsland(id, 1, localUVW);
-                        uvw2_B = LV_LocalToIsland(id, 2, localUVW);
-                    }
-                
-                    LV_SampleLightVolumeTex(uvw0_B, uvw1_B, uvw2_B, L0_B, L1r_B, L1g_B, L1b_B); // Sample Last Volume as fallback
-                
-                }
-                    
-            } else { // Blending Volume A and Volume B
-                
-                // UVW B
-                float3 uvw0_B, uvw1_B, uvw2_B;
-                
-                // Volume A UVWs
-                if (rotType_A == 0) {
-                    uvw0_A = LV_IslandFromFixedVolume(volumeID_A, 0, worldPos);
-                    uvw1_A = LV_IslandFromFixedVolume(volumeID_A, 1, worldPos);
-                    uvw2_A = LV_IslandFromFixedVolume(volumeID_A, 2, worldPos);
-                } else {
-                    uvw0_A = LV_LocalToIsland(volumeID_A, 0, localUVW_A);
-                    uvw1_A = LV_LocalToIsland(volumeID_A, 1, localUVW_A);
-                    uvw2_A = LV_LocalToIsland(volumeID_A, 2, localUVW_A);
-                }
-                
-                // Volume B UVWs
-                if (rotType_B == 0) {
-                    uvw0_B = LV_IslandFromFixedVolume(volumeID_B, 0, worldPos);
-                    uvw1_B = LV_IslandFromFixedVolume(volumeID_B, 1, worldPos);
-                    uvw2_B = LV_IslandFromFixedVolume(volumeID_B, 2, worldPos);
-                } else {
-                    uvw0_B = LV_LocalToIsland(volumeID_B, 0, localUVW_B);
-                    uvw1_B = LV_LocalToIsland(volumeID_B, 1, localUVW_B);
-                    uvw2_B = LV_LocalToIsland(volumeID_B, 2, localUVW_B);
-                }
-                
-                LV_SampleLightVolumeTex(uvw0_A, uvw1_A, uvw2_A, L0_A, L1r_A, L1g_A, L1b_A); // Sample Volume A
-                LV_SampleLightVolumeTex(uvw0_B, uvw1_B, uvw2_B, L0_B, L1r_B, L1g_B, L1b_B); // Sample Volume B
-                
+        }
+        
+        [loop] // Next, searching for volume B if A found
+        for (id++; id < _UdonLightVolumeCount; id++) {
+            localUVW = LV_LocalFromVolume(id, worldPos);
+            if (LV_PointLocalAABB(localUVW)) { // Intersection test
+                volumeID_B = id;
+                localUVW_B = localUVW;
+                isNoB = false;
+                break;
             }
-            
-            // Lerping SH components
-            L0 =  lerp(L0_B,  L0_A,  mask);
-            L1r = lerp(L1r_B, L1r_A, mask);
-            L1g = lerp(L1g_B, L1g_A, mask);
-            L1b = lerp(L1b_B, L1b_A, mask);
-            return;
+        }
+        
+        // Volume A SH components and mask to blend volume sides
+        float3 L0_A  = float3(1, 1, 1);
+        float3 L1r_A = float3(0, 0, 0);
+        float3 L1g_A = float3(0, 0, 0);
+        float3 L1b_A = float3(0, 0, 0);
 
+        // If no volumes found, using Light Probes as fallback
+        if (isNoA && _UdonLightVolumeProbesBlend) {
+            LV_SampleLightProbe(L0_, L1r_, L1g_, L1b_);
+            L0  += L0_;
+            L1r += L1r_;
+            L1g += L1g_;
+            L1b += L1b_;
+            return;
+        }
+            
+        // Fallback to lowest weight light volume if oudside of every volume
+        localUVW_A = isNoA ? localUVW : localUVW_A;
+        volumeID_A = isNoA ? _UdonLightVolumeCount - 1 : volumeID_A;
+
+        // Sampling Light Volume A
+        LV_SampleVolume(volumeID_A, localUVW_A, L0_A, L1r_A, L1g_A, L1b_A);
+        
+        float mask = LV_BoundsMask(localUVW_A, _UdonLightVolumeInvLocalEdgeSmooth[volumeID_A]);
+        if (mask == 1 || isNoA || (_UdonLightVolumeSharpBounds && isNoB)) { // Returning SH A result if it's the center of mask or out of bounds
+            L0  += L0_A;
+            L1r += L1r_A;
+            L1g += L1g_A;
+            L1b += L1b_A;
+            return;
+        }
+        
+        // Volume B SH components
+        float3 L0_B  = float3(1, 1, 1);
+        float3 L1r_B = float3(0, 0, 0);
+        float3 L1g_B = float3(0, 0, 0);
+        float3 L1b_B = float3(0, 0, 0);
+
+        if (isNoB && _UdonLightVolumeProbesBlend) { // No Volume found and light volumes blending enabled
+
+            // Sample Light Probes B
+            LV_SampleLightProbe(L0_B, L1r_B, L1g_B, L1b_B);
+
+        } else { // Blending Volume A and Volume B
+                
+            // If no volume b found, use last one found to fallback
+            localUVW_B = isNoB ? localUVW : localUVW_B;
+            volumeID_B = isNoB ? _UdonLightVolumeCount - 1 : volumeID_B;
+                
+            // Sampling Light Volume B
+            LV_SampleVolume(volumeID_B, localUVW_B, L0_B, L1r_B, L1g_B, L1b_B);
+            
+        }
+            
+        // Lerping SH components
+        L0  += lerp(L0_B,  L0_A,  mask);
+        L1r += lerp(L1r_B, L1r_A, mask);
+        L1g += lerp(L1g_B, L1g_A, mask);
+        L1b += lerp(L1b_B, L1b_A, mask);
+
+    }
+
+    void LightVolumeAdditiveSH(float3 worldPos, out float3 L0, out float3 L1r, out float3 L1g, out float3 L1b) {
+
+        // Initializing output variables
+        L0  = float3(0, 0, 0);
+        L1r = float3(0, 0, 0);
+        L1g = float3(0, 0, 0);
+        L1b = float3(0, 0, 0);
+        
+        if (!_UdonLightVolumeEnabled || _UdonLightVolumeAdditiveCount == 0) return;
+        
+        // Additive volumes variables
+        float3 localUVW = float3(0, 0, 0);
+        int addVolumesCount = 0;
+        float3 L0_, L1r_, L1g_, L1b_;
+        
+        // Iterating through all light volumes with simplified algorithm requiring Light Volumes to be sorted by weight in descending order
+        [loop]
+        for (int id = 0; id < _UdonLightVolumeAdditiveCount && addVolumesCount < _UdonLightVolumeAdditiveMaxOverdraw; id++) {
+            localUVW = LV_LocalFromVolume(id, worldPos);
+            //Intersection test
+            if (LV_PointLocalAABB(localUVW)) {
+                LV_SampleVolume(id, localUVW, L0_, L1r_, L1g_, L1b_);
+                L0 += L0_;
+                L1r += L1r_;
+                L1g += L1g_;
+                L1b += L1b_;
+                addVolumesCount++;
+            }
         }
 
     }

--- a/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/VRCLightVolumes.orlsource.meta
+++ b/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/VRCLightVolumes.orlsource.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: da91eecb091388442abad06676e829af
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: f43ee36a0ee244f697129b1aba052424, type: 3}

--- a/Packages/sh.orels.shaders/Runtime/Shaders/ORL Standard.orlshader
+++ b/Packages/sh.orels.shaders/Runtime/Shaders/ORL Standard.orlshader
@@ -52,7 +52,8 @@
     "self",
     "@/Modules/Parallax",
     "@/Modules/Details",
-    "@/Modules/VRCFeatures"
+    "@/Modules/VRCFeatures",
+    "@/Modules/VRCLightVolumes"
 }
 
 %Variables()

--- a/Packages/sh.orels.shaders/Runtime/Shaders/Toon/ORL Toon v2.orlshader
+++ b/Packages/sh.orels.shaders/Runtime/Shaders/Toon/ORL Toon v2.orlshader
@@ -17,6 +17,7 @@
     "@/Modules/AudioLink",
     "self",
     "@/Modules/Toon/v2/Main"
+    "@/Modules/VRCLightVolumes"
     "@/Modules/Toon/v2/Shading",
     "@/Modules/Toon/v2/Occlusion",
     "@/Modules/Toon/v2/Normals",
@@ -29,5 +30,5 @@
     "@/Modules/Toon/AudioLink",
     "@/Modules/Toon/v2/Emission",
     "@/Modules/Toon/v2/Outline",
-    "@/Modules/Toon/UVDiscard"
+    "@/Modules/Toon/UVDiscard",
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/34464f19-de17-4d9c-8cfa-9b5586af3901)

- Included **and enabled by default** in the Toon v2 shader (no Toon v1 support)
- Included **and disabled by default** in all the PBR (Standard) shaders to avoid adding extra stamplers/texture slots
- There is currently no support for this in VFX shaders as they do not sample lightprobes, however - you can implement it in a custom VFX shader by providing a spot for relevant hooks: `%CustomProbesSetupFunctions` and `%CustomProbesFunctions`. The latter requires creating a `half3 indirectDiffuse` variable prior to the hook, which will then get populated by the light volume color data.

### Sample Pictures
![VRChat_2025-05-05_23-16-27 666_3840x2160](https://github.com/user-attachments/assets/a25cf071-9fde-4ad4-9a02-80b419436c7d)
![VRChat_2025-05-05_23-19-30 240_3840x2160](https://github.com/user-attachments/assets/94769206-6762-4b90-bc39-332555d4b474)
![VRChat_2025-05-05_23-22-39 673_3840x2160](https://github.com/user-attachments/assets/fae33c17-17c9-4314-a0dd-2540c1c5898f)
