### PR TITLE
Skip LightVolumes on OpenGL Core

### DIFF
--- a/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/VRCLightVolumes.orlsource
+++ b/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/VRCLightVolumes.orlsource
@@ -37,6 +37,8 @@
     // All volumes count in scene
     float _UdonLightVolumeCount;
 
+    #if !SHADER_API_GLCORE
+
     // Additive volumes max overdraw count
     float _UdonLightVolumeAdditiveMaxOverdraw;
 
@@ -73,6 +75,8 @@
 
     // Color multiplier
     float4 _UdonLightVolumeColor[256];
+
+    #endif
 }
 
 %AdditionalSurfaceData()
@@ -108,7 +112,7 @@
 {
     void VRCLightVolumesCustomProbesSetup(MeshData d, inout SurfaceData o)
     {
-        #if defined(VRCLIGHTVOLUMES)
+        #if defined(VRCLIGHTVOLUMES) && !SHADER_API_GLCORE
         {
             float3 L0, L1r, L1g, L1b;
             LightVolumeSH(d.worldSpacePosition, L0, L1r, L1g, L1b);
@@ -134,7 +138,7 @@
     void VRCLightVolumesCustomProbes(SurfaceData o, MeshData d, inout half3 indirectDiffuse)
     {
         // Custom Probes
-        #if defined(VRCLIGHTVOLUMES)
+        #if defined(VRCLIGHTVOLUMES) && !SHADER_API_GLCORE
         {
             #if defined(ORL_LIGHTING_MODEL_TOON_V2)
             {
@@ -151,7 +155,7 @@
 {
     void VRCLightVolumesCustomProbesBakedSpecular(SurfaceData o, MeshData d, inout half3 indirectSpecular, inout half3 bakedSpecularColor, inout half3 bakedDominantDirection)
     {
-        #if defined(VRCLIGHTVOLUMES)
+        #if defined(VRCLIGHTVOLUMES) && !SHADER_API_GLCORE
         bakedSpecularColor = o.VRCLV_L0;
         bakedDominantDirection = o.VRCLV_L1r.xyz + o.VRCLV_L1g.xyz + o.VRCLV_L1b.xyz;
         #endif
@@ -162,7 +166,7 @@
 {
     void VRCLightVolumesCustomGI(SurfaceData o, MeshData d, inout half3 indirectDiffuse)
     {
-        #if defined(VRCLIGHTVOLUMES)
+        #if defined(VRCLIGHTVOLUMES) && !SHADER_API_GLCORE
         {
             #if defined(LIGHTMAP_ON)
             {
@@ -191,21 +195,26 @@
 
     // Calculates local UVW using volume ID
     float3 LV_LocalFromVolume(int volumeID, float3 worldPos) {
+        #if !SHADER_API_GLCORE
         return mul(_UdonLightVolumeInvWorldMatrix[volumeID], float4(worldPos, 1.0)).xyz;
+        #endif
     }
 
     // Calculates Island UVW from local UVW
     float3 LV_LocalToIsland(int volumeID, int texID, float3 localUVW){
+        #if !SHADER_API_GLCORE
         // UVW bounds
         int uvwID = volumeID * 3 + texID;
         float3 uvwMin = _UdonLightVolumeUvwMin[uvwID].xyz;
         float3 uvwMax = _UdonLightVolumeUvwMax[uvwID].xyz;
         // Ramapping world bounds to UVW bounds
         return clamp(lerp(uvwMin, uvwMax, localUVW + 0.5), uvwMin, uvwMax);
+        #endif
     }
 
     // Samples 3 SH textures and packing them into L1 channels
     void LV_SampleLightVolumeTex(float3 uvw0, float3 uvw1, float3 uvw2, out float3 L0, out float3 L1r, out float3 L1g, out float3 L1b) {
+        #if !SHADER_API_GLCORE
         // Sampling 3D Atlas
         float4 tex0 = SAMPLE_TEXTURE3D_LOD(_UdonLightVolume, sampler_UdonLightVolume, uvw0, 0);
         float4 tex1 = SAMPLE_TEXTURE3D_LOD(_UdonLightVolume, sampler_UdonLightVolume, uvw1, 0);
@@ -215,6 +224,7 @@
         L1r = float3(tex1.r, tex2.r, tex0.a);
         L1g = float3(tex1.g, tex2.g, tex1.a);
         L1b = float3(tex1.b, tex2.b, tex2.a);
+        #endif
     }
 
     // Bounds mask for a volume rotated in world space, using local UVW
@@ -240,6 +250,8 @@
 
     // Samples a Volume with ID and Local UVW
     void LV_SampleVolume(int id, float3 localUVW, out float3 L0, out float3 L1r, out float3 L1g, out float3 L1b) {
+
+        #if !SHADER_API_GLCORE
         
         // Additive UVW
         float3 uvw0 = LV_LocalToIsland(id, 0, localUVW);
@@ -261,6 +273,8 @@
             L1g = LV_MultiplyVectorByQuaternion(L1g, _UdonLightVolumeRotation[id]);
             L1b = LV_MultiplyVectorByQuaternion(L1b, _UdonLightVolumeRotation[id]);
         }
+
+        #endif
                     
     }
 
@@ -283,6 +297,8 @@
             LV_SampleLightProbe(L0, L1r, L1g, L1b);
             return;
         }
+
+        #if !SHADER_API_GLCORE
         
         int volumeID_A = -1; // Main, dominant volume ID
         int volumeID_B = -1; // Secondary volume ID to blend main with
@@ -397,9 +413,13 @@
         L1g += lerp(L1g_B, L1g_A, mask);
         L1b += lerp(L1b_B, L1b_A, mask);
 
+        #endif
+
     }
 
     void LightVolumeAdditiveSH(float3 worldPos, out float3 L0, out float3 L1r, out float3 L1g, out float3 L1b) {
+
+        #if !SHADER_API_GLCORE
 
         // Initializing output variables
         L0  = float3(0, 0, 0);
@@ -428,6 +448,8 @@
                 addVolumesCount++;
             }
         }
+
+        #endif
 
     }
 }

--- a/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/VRCLightVolumes.orlsource
+++ b/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/VRCLightVolumes.orlsource
@@ -29,15 +29,31 @@
     [Toggle(VRCLIGHTVOLUMES)]_VRCLightVolumesEnabled("Enable VRC Light Volumes", Int) = 0
 }
 
+%ShaderFeatures()
+{
+    #if !defined(SHADER_API_GLES) && !defined(SHADER_API_GLES3) && !defined(SHADER_API_GLCORE)
+        #pragma shader_feature_local_fragment VRCLIGHTVOLUMES
+    #endif
+}
+
+%ShaderDefines()
+{
+    #if defined(VRCLIGHTVOLUMES) && !defined(SHADER_API_GLES) && !defined(SHADER_API_GLES3) && !defined(SHADER_API_GLCORE)
+        #define INTEGRATE_VRCLIGHTVOLUMES
+
+        #define _INTEGRATE_CUSTOMPROBES
+        #define _INTEGRATE_CUSTOMGI_FLEX
+    #endif
+}
+
 %Variables()
 {
+    #if defined(INTEGRATE_VRCLIGHTVOLUMES)
     // Are Light Volumes enabled on scene?
     float _UdonLightVolumeEnabled;
 
     // All volumes count in scene
     float _UdonLightVolumeCount;
-
-    #if !SHADER_API_GLCORE
 
     // Additive volumes max overdraw count
     float _UdonLightVolumeAdditiveMaxOverdraw;
@@ -75,13 +91,12 @@
 
     // Color multiplier
     float4 _UdonLightVolumeColor[256];
-
     #endif
 }
 
 %AdditionalSurfaceData()
 {
-    #if defined(VRCLIGHTVOLUMES)
+    #if defined(INTEGRATE_VRCLIGHTVOLUMES)
     float3 VRCLV_L0;
     float3 VRCLV_L1r;
     float3 VRCLV_L1g;
@@ -91,20 +106,9 @@
 
 %Textures()
 {
+    #if defined(INTEGRATE_VRCLIGHTVOLUMES)
     TEXTURE3D(_UdonLightVolume);
     SAMPLER(sampler_UdonLightVolume);
-}
-
-%ShaderFeatures()
-{
-    #pragma shader_feature_local_fragment VRCLIGHTVOLUMES
-}
-
-%ShaderDefines()
-{
-    #if defined(VRCLIGHTVOLUMES)
-        #define _INTEGRATE_CUSTOMPROBES
-        #define _INTEGRATE_CUSTOMGI_FLEX
     #endif
 }
 
@@ -112,7 +116,7 @@
 {
     void VRCLightVolumesCustomProbesSetup(MeshData d, inout SurfaceData o)
     {
-        #if defined(VRCLIGHTVOLUMES) && !SHADER_API_GLCORE
+        #if defined(INTEGRATE_VRCLIGHTVOLUMES)
         {
             float3 L0, L1r, L1g, L1b;
             LightVolumeSH(d.worldSpacePosition, L0, L1r, L1g, L1b);
@@ -138,7 +142,7 @@
     void VRCLightVolumesCustomProbes(SurfaceData o, MeshData d, inout half3 indirectDiffuse)
     {
         // Custom Probes
-        #if defined(VRCLIGHTVOLUMES) && !SHADER_API_GLCORE
+        #if defined(INTEGRATE_VRCLIGHTVOLUMES)
         {
             #if defined(ORL_LIGHTING_MODEL_TOON_V2)
             {
@@ -155,7 +159,7 @@
 {
     void VRCLightVolumesCustomProbesBakedSpecular(SurfaceData o, MeshData d, inout half3 indirectSpecular, inout half3 bakedSpecularColor, inout half3 bakedDominantDirection)
     {
-        #if defined(VRCLIGHTVOLUMES) && !SHADER_API_GLCORE
+        #if defined(INTEGRATE_VRCLIGHTVOLUMES)
         bakedSpecularColor = o.VRCLV_L0;
         bakedDominantDirection = o.VRCLV_L1r.xyz + o.VRCLV_L1g.xyz + o.VRCLV_L1b.xyz;
         #endif
@@ -166,7 +170,7 @@
 {
     void VRCLightVolumesCustomGI(SurfaceData o, MeshData d, inout half3 indirectDiffuse)
     {
-        #if defined(VRCLIGHTVOLUMES) && !SHADER_API_GLCORE
+        #if defined(INTEGRATE_VRCLIGHTVOLUMES)
         {
             #if defined(LIGHTMAP_ON)
             {
@@ -182,6 +186,7 @@
 
 %PassFunctions()
 {
+    #if defined(INTEGRATE_VRCLIGHTVOLUMES)
     // Rotates vector by quaternion
     float3 LV_MultiplyVectorByQuaternion(float3 v, float4 q) {
         float3 t = 2.0 * cross(q.xyz, v);
@@ -195,26 +200,21 @@
 
     // Calculates local UVW using volume ID
     float3 LV_LocalFromVolume(int volumeID, float3 worldPos) {
-        #if !SHADER_API_GLCORE
         return mul(_UdonLightVolumeInvWorldMatrix[volumeID], float4(worldPos, 1.0)).xyz;
-        #endif
     }
 
     // Calculates Island UVW from local UVW
     float3 LV_LocalToIsland(int volumeID, int texID, float3 localUVW){
-        #if !SHADER_API_GLCORE
         // UVW bounds
         int uvwID = volumeID * 3 + texID;
         float3 uvwMin = _UdonLightVolumeUvwMin[uvwID].xyz;
         float3 uvwMax = _UdonLightVolumeUvwMax[uvwID].xyz;
         // Ramapping world bounds to UVW bounds
         return clamp(lerp(uvwMin, uvwMax, localUVW + 0.5), uvwMin, uvwMax);
-        #endif
     }
 
     // Samples 3 SH textures and packing them into L1 channels
     void LV_SampleLightVolumeTex(float3 uvw0, float3 uvw1, float3 uvw2, out float3 L0, out float3 L1r, out float3 L1g, out float3 L1b) {
-        #if !SHADER_API_GLCORE
         // Sampling 3D Atlas
         float4 tex0 = SAMPLE_TEXTURE3D_LOD(_UdonLightVolume, sampler_UdonLightVolume, uvw0, 0);
         float4 tex1 = SAMPLE_TEXTURE3D_LOD(_UdonLightVolume, sampler_UdonLightVolume, uvw1, 0);
@@ -224,7 +224,6 @@
         L1r = float3(tex1.r, tex2.r, tex0.a);
         L1g = float3(tex1.g, tex2.g, tex1.a);
         L1b = float3(tex1.b, tex2.b, tex2.a);
-        #endif
     }
 
     // Bounds mask for a volume rotated in world space, using local UVW
@@ -250,9 +249,6 @@
 
     // Samples a Volume with ID and Local UVW
     void LV_SampleVolume(int id, float3 localUVW, out float3 L0, out float3 L1r, out float3 L1g, out float3 L1b) {
-
-        #if !SHADER_API_GLCORE
-        
         // Additive UVW
         float3 uvw0 = LV_LocalToIsland(id, 0, localUVW);
         float3 uvw1 = LV_LocalToIsland(id, 1, localUVW);
@@ -272,10 +268,7 @@
             L1r = LV_MultiplyVectorByQuaternion(L1r, _UdonLightVolumeRotation[id]);
             L1g = LV_MultiplyVectorByQuaternion(L1g, _UdonLightVolumeRotation[id]);
             L1b = LV_MultiplyVectorByQuaternion(L1b, _UdonLightVolumeRotation[id]);
-        }
-
-        #endif
-                    
+        }            
     }
 
     // Calculate Light Volume Color based on all SH components provided and the world normal
@@ -298,8 +291,6 @@
             return;
         }
 
-        #if !SHADER_API_GLCORE
-        
         int volumeID_A = -1; // Main, dominant volume ID
         int volumeID_B = -1; // Secondary volume ID to blend main with
 
@@ -412,15 +403,9 @@
         L1r += lerp(L1r_B, L1r_A, mask);
         L1g += lerp(L1g_B, L1g_A, mask);
         L1b += lerp(L1b_B, L1b_A, mask);
-
-        #endif
-
     }
 
     void LightVolumeAdditiveSH(float3 worldPos, out float3 L0, out float3 L1r, out float3 L1g, out float3 L1b) {
-
-        #if !SHADER_API_GLCORE
-
         // Initializing output variables
         L0  = float3(0, 0, 0);
         L1r = float3(0, 0, 0);
@@ -448,8 +433,6 @@
                 addVolumesCount++;
             }
         }
-
-        #endif
-
     }
+    #endif
 }


### PR DESCRIPTION
Skip Compilation of VRCLightVolumes on OpenGL Core were the number of uniforms exceeds the maximum of 1024 uniforms.