### PR TITLE
Fix VRCFeatures "Hide From Main View" also hiding in mirrors

### DIFF
--- a/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/VRCFeatures.orlsource
+++ b/Packages/sh.orels.shaders.generator/Runtime/Sources/Modules/VRCFeatures.orlsource
@@ -48,7 +48,7 @@
     void VRCFeaturesVertex(inout VertexData v)
     {
         #if defined(VRC_FEATURES)
-        bool isMainView = _VRChatCameraMode == 0;
+        bool isMainView = _VRChatCameraMode == 0 && _VRChatMirrorMode == 0;
         bool isInVRHandCam = _VRChatCameraMode == 1;
         bool isInDesktopHandCam = _VRChatCameraMode == 2;
         bool isInVR = isVR__local();


### PR DESCRIPTION
In the VRCFeatures module, I think `bool isMainView` needs to also check whether or not it is rendering in a mirror, otherwise hiding from main view also hides it from the mirror. I'm not 100% certain there isn't some logical reason you had it set up like that though that I'm just not thinking of. 